### PR TITLE
fix: various fix for the to-geostyler part

### DIFF
--- a/src/esri/types/labeling/LabelFeatureType.ts
+++ b/src/esri/types/labeling/LabelFeatureType.ts
@@ -1,5 +1,5 @@
 export enum LabelFeatureType {
-    Point,
-    Line,
-    Polygon
+    Point = 'Point' ,
+    Line = 'Line',
+    Polygon = 'Polygon'
 }

--- a/src/expressions.ts
+++ b/src/expressions.ts
@@ -10,7 +10,7 @@ export const convertExpression = (rawExpression: string, engine: LabelExpression
     if (toLowerCase) {
         expression = rawExpression.toLowerCase();
     }
-    
+
     if (expression.includes("+") || expression.includes("&")) {
         let tokens: string[] = expression.includes("+") ? expression.split("+").reverse() : expression.split("&").reverse();
         let addends = [];
@@ -18,7 +18,7 @@ export const convertExpression = (rawExpression: string, engine: LabelExpression
             if (token.includes("[")) {
                 addends.push(["PropertyName", processPropertyName(token)]);
             } else {
-                let literal = token.replace('"', "");
+                let literal = token.replaceAll('"', "");
                 addends.push(replaceSpecialLiteral(literal));
             }
             let allOps: any = addends[0];

--- a/src/processSymbolLayer.ts
+++ b/src/processSymbolLayer.ts
@@ -7,7 +7,7 @@ import {
   extractFillColor,
   extractFillOpacity,
   extractStroke,
-  ptToPxProp,
+  ptToPxProp, toHex,
   WARNINGS,
 } from "./toGeostylerUtils";
 import { processSymbolReference } from "./processSymbolReference";
@@ -90,12 +90,11 @@ const processSymbolCharacterMarker = (
   layer: any,
   options: { [key: string]: any }
 ): { [key: string]: any } => {
-  let replaceesri =
-    options.replaceesri === undefined ? false : options.replaceesri;
-  let fontFamily = layer.fontFamilyName;
-  let charindex = layer.characterIndex;
-  let hexcode = charindex.toString(16);
-  let size = ptToPxProp(layer, "size", 12);
+  const replaceesri = !!options.replaceesri;
+  const fontFamily = layer.fontFamilyName;
+  const charindex = layer.characterIndex;
+  const hexcode = toHex(charindex);
+  const size = ptToPxProp(layer, "size", 12);
 
   let name: string;
   if (fontFamily === ESRI_SYMBOLS_FONT && replaceesri) {
@@ -107,7 +106,7 @@ const processSymbolCharacterMarker = (
   let rotate = layer.rotation === undefined ? 0 : layer.rotation;
   let rotateClockwise =
     layer.rotateClockwise === undefined ? false : layer.rotateClockwise;
-  if (!rotateClockwise) {
+  if (!rotateClockwise && rotate !== 0) {
     rotate *= -1;
   }
 
@@ -146,26 +145,26 @@ const processSymbolCharacterMarker = (
 };
 
 const processSymbolVectorMarker = (layer: any): Marker => {
-    if (layer.size) {
-        layer.size = ptToPxProp(layer, "size", 3);
-    }
-    // Default values
-    let fillColor = "#ff0000";
-    let strokeColor = "#000000";
-    let strokeWidth = 1.0;
-    let markerSize = 10;
-    let strokeOpacity = 1;
-    let wellKnownName = "circle";
-    let maxX: number | null = null;
-    let maxY: number | null = null;
+  if (layer.size) {
+    layer.size = ptToPxProp(layer, "size", 3);
+  }
+  // Default values
+  let fillColor = "#ff0000";
+  let strokeColor = "#000000";
+  let strokeWidth = 1.0;
+  let markerSize = 10;
+  let strokeOpacity = 1;
+  let wellKnownName = "circle";
+  let maxX: number | null = null;
+  let maxY: number | null = null;
 
-  let markerGraphics =
+  const markerGraphics =
     layer.markerGraphics !== undefined ? layer.markerGraphics : [];
   if (markerGraphics.length > 0) {
     // TODO: support multiple marker graphics
-    let markerGraphic = markerGraphics[0];
-    let marker = processSymbolReference(markerGraphic, {})[0];
-    let sublayers = markerGraphic.symbol.symbolLayers.filter(
+    const markerGraphic = markerGraphics[0];
+    const marker = processSymbolReference(markerGraphic, {})[0];
+    const sublayers = markerGraphic.symbol.symbolLayers.filter(
       (sublayer: any) => sublayer.enable
     );
     fillColor = extractFillColor(sublayers);
@@ -174,8 +173,8 @@ const processSymbolVectorMarker = (layer: any): Marker => {
       marker.size !== undefined
         ? marker.size
         : layer.size !== undefined
-        ? layer.size
-        : 10;
+          ? layer.size
+          : 10;
     if (markerGraphic.symbol.type === "CIMPointSymbol") {
       wellKnownName = marker.wellKnownName ?? "";
     } else if (
@@ -212,7 +211,7 @@ const processSymbolVectorMarker = (layer: any): Marker => {
     marker["maxY"] = maxY;
   }
 
-  let markerPlacement =
+  const markerPlacement =
     layer.markerPlacement != undefined &&
     layer.markerPlacement.placementTemplate !== undefined
       ? layer.markerPlacement.placementTemplate
@@ -351,7 +350,7 @@ const processEffect = (effect: Record<string, any>): Record<string, any> => {
     if (dasharrayValues.length > 1) {
       return {
         dasharrayValues: dasharrayValues,
-        dasharray: dasharrayValues.join(" "),
+        dasharray: dasharrayValues, // TODO was a string, can be simplified now
       };
     }
   } else if (effect.type === "CIMGeometricEffectOffset") {

--- a/src/processSymbolReference.ts
+++ b/src/processSymbolReference.ts
@@ -9,7 +9,7 @@ import {
   extractFillColor,
   extractFillOpacity,
   extractStroke,
-  ptToPxProp,
+  ptToPxProp, toHex,
 } from './toGeostylerUtils';
 import {
   MarkerPlacement,
@@ -126,7 +126,7 @@ const processOrientedMarkerAtEndOfLine = (
 ): Record<string, any> | undefined => {
   let markerPositionFnc: string, markerRotationFnc: string, rotation: number;
 
-  if (orientedMarker == 'start') {
+  if (orientedMarker === 'start') {
     markerPositionFnc = MarkerPlacementPosition.START;
     markerRotationFnc = MarkerPlacementAngle.START;
     rotation = layer?.rotation ?? 180;
@@ -138,10 +138,10 @@ const processOrientedMarkerAtEndOfLine = (
     return undefined;
   }
 
-  const replaceesri = options?.replaceesri ?? false;
+  const replaceesri = !!options?.replaceesri;
   const fontFamily = layer.fontFamilyName;
   const charindex = layer.characterIndex;
-  const hexcode = charindex.toString(16);
+  const hexcode = toHex(charindex);
 
   let name;
   if (fontFamily === ESRI_SYMBOLS_FONT && replaceesri) {

--- a/src/toGeostyler.ts
+++ b/src/toGeostyler.ts
@@ -1,17 +1,8 @@
-import { Rule as FIXMERULE, Style } from 'geostyler-style';
-import {
-  convertExpression,
-  convertWhereClause,
-  processRotationExpression,
-} from './expressions';
-import { Options, Rule, Symbolizer } from './badTypes';
-import {
-  extractFillColor,
-  extractFontWeight,
-  ptToPxProp,
-  WARNINGS,
-} from './toGeostylerUtils';
-import { processSymbolReference } from './processSymbolReference';
+import {Rule as FIXMERULE, Style} from 'geostyler-style';
+import {convertExpression, convertWhereClause, processRotationExpression,} from './expressions';
+import {Options, Rule, Symbolizer} from './badTypes';
+import {extractFillColor, extractFontWeight, ptToPxProp, WARNINGS,} from './toGeostylerUtils';
+import {processSymbolReference} from './processSymbolReference';
 import {
   CIMFeatureLayer,
   CIMLabelClass,
@@ -20,7 +11,7 @@ import {
   LabelExpressionEngine,
   LabelFeatureType,
 } from './esri/types';
-import { CIMTextSymbol } from './esri/types/symbols';
+import {CIMTextSymbol} from './esri/types/symbols';
 
 const usedIcons: string[] = [];
 
@@ -41,6 +32,11 @@ const processLayer = (
     rules: [],
   };
 
+  options = {
+    ...{ toLowerCase: true, replaceesri: false},
+    ...options,
+  };
+
   if (layer.type === 'CIMFeatureLayer') {
     style.rules = processFeatureLayer(layer, options);
   } else if (layer.type === 'CIMRasterLayer') {
@@ -54,7 +50,7 @@ const processFeatureLayer = (
   layer: CIMFeatureLayer,
   options: Options = {}
 ): FIXMERULE[] => {
-  const toLowerCase = options.toLowerCase || false;
+  const toLowerCase = !!options.toLowerCase;
   const renderer = layer.renderer!;
   const rules: Rule[] = [];
 
@@ -117,7 +113,7 @@ const processClassBreaksRenderer = (
   const symbolsAscending: Symbolizer[][] = [];
   const field = renderer.field;
   let lastbound: number | null = null;
-  const toLowerCase = options.toLowerCase || false;
+  const toLowerCase = !!options.toLowerCase;
   const rotation = getSymbolRotationFromVisualVariables(renderer, toLowerCase);
 
   for (const classbreak of renderer.breaks || []) {
@@ -176,10 +172,10 @@ const processClassBreaksRenderer = (
 
 const processLabelClass = (
   labelClass: CIMLabelClass,
-  toLowerCase: boolean = false
+  toLowerCase: boolean,
 ): Rule => {
   // todo ConvertTextSymbol:
-  if (labelClass.textSymbol?.symbol?.type != 'CIMTextSymbol') {
+  if (labelClass.textSymbol?.symbol?.type !== 'CIMTextSymbol') {
     return { name: '', symbolizers: [] };
   }
 
@@ -407,8 +403,11 @@ const getSymbolRotationFromVisualVariables = (
 const processScaleDenominator = (
   minimumScale?: number,
   maximumScale?: number
-): { [key: string]: number } => {
-  let scaleDenominator: { [key: string]: number } = {};
+): { [key: string]: number } | null => {
+  if (minimumScale === undefined && maximumScale === undefined) {
+    return null;
+  }
+  const scaleDenominator: { [key: string]: number } = {};
   if (minimumScale !== undefined) {
     scaleDenominator.max = minimumScale;
   }

--- a/src/toGeostylerUtils.ts
+++ b/src/toGeostylerUtils.ts
@@ -3,6 +3,10 @@ import {processColor, processOpacity} from './processUtils';
 
 export const WARNINGS: string[] = [];
 
+export const toHex = (value: number): string => {
+  return `0x${value.toString(16)}`;
+};
+
 export const esriFontToStandardSymbols = (charIndex: number): string => {
   const mapping: { [index: number]: string } = {
     33: 'circle',


### PR DESCRIPTION
In the aim of having the same to-geostyler result than in the legacy lyrx2sld project.

 - Detect right Feature type (Line/point...)
 - restore lyrx2sld default options
 - fix hex values
 - Remove empty scaleDenominator
 - use replaceAll and not replace to replace double quotes (`test "o" matic` was changed to `test 'o" matic`)
 - use `0` instead of `-0` for rotations

Exception: some things was "wrong" in lyrx2sld regarding the Geostyler types, or style:
See the wiki to read the diffs https://github.com/geostyler/geostyler-lyrx-parser/wiki