### PR TITLE
fix: rotation is now between 360 degree and gets the right symbol

### DIFF
--- a/src/processSymbolLayer.ts
+++ b/src/processSymbolLayer.ts
@@ -6,7 +6,11 @@ import {
   POLYGON_FILL_RESIZE_FACTOR,
   ptToPx,
 } from "./constants.ts";
-import { processColor, processOpacity } from "./processUtils.ts";
+import {
+  angleIn360Degrees,
+  processColor,
+  processOpacity,
+} from "./processUtils.ts";
 import {
   esriFontToStandardSymbols,
   extractFillColor,
@@ -787,9 +791,10 @@ const getTiltedHatchMarker = (): WellKnownName[] => {
 };
 
 const hatchMarkerForAngle = (angle: number): WellKnownName => {
+  const angle360 = angleIn360Degrees(angle);
   const straightHatchMarkers = getStraightHatchMarker();
   const tiltedHatchMarkers = getTiltedHatchMarker();
-  const quadrant = Math.floor(((angle + 22.5) % 180) / 45.0);
+  const quadrant = Math.floor(((angle360 + 22.5) % 180) / 45.0);
 
   return [
     straightHatchMarkers[0],

--- a/src/processUtils.ts
+++ b/src/processUtils.ts
@@ -7,6 +7,10 @@ export const processOpacity = (color: CIMColor | null): number => {
   return color.values[color.values.length - 1] / 100;
 };
 
+export const angleIn360Degrees = (angle: number): number => {
+  return ((angle % 360) + 360) % 360;
+};
+
 export const processColor = (color: CIMColorType): string => {
   if (color === null) {
     return "#000000";


### PR DESCRIPTION
Fix #116 
Solves issues like "undefined" on toLowerCase on some sld tranformation. Now it get the right symbol.