### PR TITLE
fix(#163): fix scaling add offset vector marker

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint:typecheck:test": "npm run lint && npm run typecheck && npm run test"
   },
   "dependencies": {
-    "geostyler-style": "^10.4.0",
+    "geostyler-style": "^11.0.2",
     "jimp": "^1.6.0"
   },
   "devDependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,13 +1,11 @@
 export const ESRI_SYMBOLS_FONT: string = "ESRI Default Marker";
 export const POLYGON_FILL_RESIZE_FACTOR: number = 2 / 3;
-export const OFFSET_FACTOR: number = 4 / 3;
+export const SCALE_FACTOR: number = 3 / 2;
 export const ESRI_SPECIAL_FONT: string[] = [
   "ttf://ESRI SDS 2.00",
   "ttf://ESRI SDS 1.95",
 ];
 export const ESRI_SPECIAL_FONT_RESIZE_FACTOR: number = 1.8;
-
-export const PT_TO_PX_FACTOR: number = 4 / 3;
 
 export enum MarkerPlacementPosition {
   START = "startPoint",
@@ -20,5 +18,5 @@ export enum MarkerPlacementAngle {
 }
 
 export const ptToPx = (pt: number): number => {
-  return pt * PT_TO_PX_FACTOR;
+  return pt * (4 / 3);
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,8 @@ export const ESRI_SPECIAL_FONT: string[] = [
 ];
 export const ESRI_SPECIAL_FONT_RESIZE_FACTOR: number = 1.8;
 
+export const PT_TO_PX_FACTOR: number = 4 / 3;
+
 export enum MarkerPlacementPosition {
   START = "startPoint",
   END = "endPoint",
@@ -18,6 +20,5 @@ export enum MarkerPlacementAngle {
 }
 
 export const ptToPx = (pt: number): number => {
-  const PT_TO_PX_FACTOR: number = 4 / 3;
   return pt * PT_TO_PX_FACTOR;
 };

--- a/src/esri/types/symbols/CIMSymbol.ts
+++ b/src/esri/types/symbols/CIMSymbol.ts
@@ -1,6 +1,7 @@
 import { CIMObject } from "../CIMObject.ts";
 import { CIMColor } from "./CIMTextSymbol.ts";
 import { CIMSymbolReference } from "../labeling";
+import { Frame } from "./Frame.ts";
 
 export type CIMColorType = CIMColor & CIMObject;
 
@@ -34,7 +35,15 @@ export type SymbolLayer = CIMObject & {
   size: number;
   symbol: CIMSymbol;
   respectFrame: boolean;
+  frame?: Frame;
   url?: string;
+  anchorPoint?: {
+    x: number;
+    y: number;
+  };
+  anchorPointUnits?: string;
+  offsetX?: number;
+  offsetY?: number;
 };
 
 export type CIMSymbol = CIMObject & {

--- a/src/esri/types/symbols/Frame.ts
+++ b/src/esri/types/symbols/Frame.ts
@@ -1,0 +1,32 @@
+/**
+ * Represents a frame with coordinate boundaries.
+ * Used to define the spatial extent of a symbol or marker.
+ * This is a property of CIMVectorMarker, not a standalone CIM type.
+ */
+export type Frame = {
+  xmin: number;
+  xmax: number;
+  ymin: number;
+  ymax: number;
+};
+
+/**
+ * Calculates the width of a frame.
+ */
+export const getFrameWidth = (frame: Frame): number => {
+  return Math.abs(frame.xmax - frame.xmin);
+};
+
+/**
+ * Calculates the height of a frame.
+ */
+export const getFrameHeight = (frame: Frame): number => {
+  return Math.abs(frame.ymax - frame.ymin);
+};
+
+/**
+ * Calculates the maximum dimension (width or height) of a frame.
+ */
+export const getFrameMax = (frame: Frame): number => {
+  return Math.max(getFrameWidth(frame), getFrameHeight(frame));
+};

--- a/src/esri/types/symbols/index.ts
+++ b/src/esri/types/symbols/index.ts
@@ -1,2 +1,3 @@
 export * from "./CIMSymbol.ts";
 export * from "./CIMTextSymbol.ts";
+export * from "./Frame.ts";

--- a/src/processSymbolReference.ts
+++ b/src/processSymbolReference.ts
@@ -6,6 +6,7 @@ import { CIMSymbolReference } from "./esri/types/labeling/CIMSymbolReference.ts"
 export const processSymbolReference = async (
   symbolref: CIMSymbolReference,
   options: Options,
+  outerSize?: number,
 ): Promise<Symbolizer[]> => {
   const symbol = symbolref.symbol;
   const symbolizers: Symbolizer[] = [];
@@ -24,6 +25,7 @@ export const processSymbolReference = async (
       layer,
       symbol,
       options,
+      outerSize,
     );
     if (processedSymbolLayers) symbolizers.push(...processedSymbolLayers);
   }

--- a/src/processSymbolReference.ts
+++ b/src/processSymbolReference.ts
@@ -7,6 +7,7 @@ export const processSymbolReference = async (
   symbolref: CIMSymbolReference,
   options: Options,
   outerSize?: number,
+  outerFrameMax?: number,
 ): Promise<Symbolizer[]> => {
   const symbol = symbolref.symbol;
   const symbolizers: Symbolizer[] = [];
@@ -26,6 +27,7 @@ export const processSymbolReference = async (
       symbol,
       options,
       outerSize,
+      outerFrameMax,
     );
     if (processedSymbolLayers) symbolizers.push(...processedSymbolLayers);
   }

--- a/src/wktGeometries.ts
+++ b/src/wktGeometries.ts
@@ -38,15 +38,22 @@ export const toWKT = (
 
     // Check if it's a simple circle (single arc that closes)
     const firstCurve = curveRing[1];
-    if (firstCurve && curveRing.length === 2) {
+    if (firstCurve && curveRing.length === 2 && Array.isArray(startPoint)) {
       const curve = firstCurve?.a || firstCurve?.b || firstCurve?.c;
-      if (curve && Array.isArray(startPoint)) {
+      if (curve) {
         const endPoint = curve[0];
         const centerPoint = curve[1];
         if (JSON.stringify(endPoint) === JSON.stringify(startPoint)) {
+          // It's a circle - convert to WKT polygon
           const radius = distanceBetweenPoints(startPoint, centerPoint);
+          const circleCoords = approximateCircle(centerPoint, radius, 32);
+          const normalizedCoords = heightNormalized(circleCoords);
+          const coordinates = normalizedCoords
+            .map((j) => j.join(" "))
+            .join(", ");
           return {
-            wellKnownName: "circle" as WellKnownName,
+            wellKnownName: `wkt://POLYGON((${coordinates}))` as WellKnownName,
+            // Return the original radius (not normalized) for proper scaling
             maxX: radius,
             maxY: radius,
           };
@@ -87,7 +94,7 @@ const heightNormalized = (coords: number[][]): number[][] => {
   // Normalize by height and center around (0, 0)
   return coords.map((coord) => [
     (coord[0] - centerX) / height,
-    (coord[1] - centerY) / height
+    (coord[1] - centerY) / height,
   ]);
 };
 
@@ -166,6 +173,23 @@ const curveRingToCoordinates = (
     }
   }
 
+  return coords;
+};
+
+const approximateCircle = (
+  centerPoint: number[],
+  radius: number,
+  segments: number = 32,
+): number[][] => {
+  const coords: number[][] = [];
+  for (let i = 0; i < segments; i++) {
+    const angle = (2 * Math.PI * i) / segments;
+    const x = centerPoint[0] + radius * Math.cos(angle);
+    const y = centerPoint[1] + radius * Math.sin(angle);
+    coords.push([x, y]);
+  }
+  // Close the ring by adding the first point again
+  coords.push(coords[0]);
   return coords;
 };
 

--- a/src/wktGeometries.ts
+++ b/src/wktGeometries.ts
@@ -73,10 +73,22 @@ export const toWKT = (
 };
 
 const heightNormalized = (coords: number[][]): number[][] => {
-  const height =
-    Math.max(...coords.map((coord) => coord[1])) -
-    Math.min(...coords.map((coord) => coord[1]));
-  return coords.map((coord) => [coord[0] / height, coord[1] / height]);
+  const minX = Math.min(...coords.map((coord) => coord[0]));
+  const maxX = Math.max(...coords.map((coord) => coord[0]));
+  const minY = Math.min(...coords.map((coord) => coord[1]));
+  const maxY = Math.max(...coords.map((coord) => coord[1]));
+  
+  const height = maxY - minY;
+  
+  // Calculate the center of the bounding box
+  const centerX = (minX + maxX) / 2;
+  const centerY = (minY + maxY) / 2;
+  
+  // Normalize by height and center around (0, 0)
+  return coords.map((coord) => [
+    (coord[0] - centerX) / height,
+    (coord[1] - centerY) / height
+  ]);
 };
 
 const distanceBetweenPoints = (a: number[], b: number[]): number => {

--- a/tests/testdata/point/point_marker_anchor_offset.lyrx
+++ b/tests/testdata/point/point_marker_anchor_offset.lyrx
@@ -1,0 +1,1558 @@
+{
+  "type" : "CIMLayerDocument",
+  "version" : "3.4.0",
+  "build" : 55405,
+  "layers" : [
+    "CIMPATH=Map/Parkpl_tze4.json"
+  ],
+  "layerDefinitions" : [
+    {
+      "type" : "CIMFeatureLayer",
+      "name" : "Parkplätze",
+      "uRI" : "CIMPATH=Map/Parkpl_tze4.json",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : -62135596800000
+      },
+      "metadataURI" : "CIMPATH=Metadata/b41210729d2bf5bb42c4393b2056b587.xml",
+      "useSourceMetadata" : true,
+      "description" : "parkpl_2025",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "elevationSurfaceLayerURI" : "CIMPATH=Map/4be32e97315a4e45b7da6df7af90191d.json"
+      },
+      "expanded" : true,
+      "layerType" : "Operational",
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "allowDrapingOnIntegratedMesh" : true,
+      "autoGenerateFeatureTemplates" : true,
+      "featureElevationExpression" : "0",
+      "featureTable" : {
+        "type" : "CIMFeatureTable",
+        "displayField" : "ck",
+        "editable" : true,
+        "fieldDescriptions" : [
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "ck",
+            "fieldName" : "ck",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "beschr",
+            "fieldName" : "beschr",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Shape",
+            "fieldName" : "Shape",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "nutzung",
+            "fieldName" : "nutzung",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Eigentuemer",
+            "fieldName" : "Eigentuemer",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Bemerkungen",
+            "fieldName" : "Bemerkungen",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Anzahl_Parkpletze",
+            "fieldName" : "Anzahl_Parkplaetze",
+            "numberFormat" : {
+              "type" : "CIMNumericFormat",
+              "alignmentOption" : "esriAlignRight",
+              "alignmentWidth" : 0,
+              "roundingOption" : "esriRoundNumberOfDecimals",
+              "roundingValue" : 0
+            },
+            "visible" : true,
+            "searchMode" : "Exact"
+          }
+        ],
+        "dataConnection" : {
+          "type" : "CIMStandardDataConnection",
+          "workspaceConnectionString" : "",
+          "workspaceFactory" : "SDE",
+          "dataset" : "AGIS.atb_parkpl",
+          "datasetType" : "esriDTFeatureClass"
+        },
+        "studyAreaSpatialRel" : "esriSpatialRelUndefined",
+        "searchOrder" : "esriSearchOrderSpatial"
+      },
+      "featureTemplates" : [
+        {
+          "type" : "CIMRowTemplate",
+          "name" : "Parkplatz ",
+          "defaultValues" : {
+            "type" : "PropertySet",
+            "propertySetItems" : [
+              "NUTZUNG",
+              "Parkplatz "
+            ]
+          }
+        },
+        {
+          "type" : "CIMRowTemplate",
+          "name" : "Stellplatz",
+          "defaultValues" : {
+            "type" : "PropertySet",
+            "propertySetItems" : [
+              "NUTZUNG",
+              "Stellplatz"
+            ]
+          }
+        },
+        {
+          "type" : "CIMRowTemplate",
+          "name" : "Rastplatz ",
+          "defaultValues" : {
+            "type" : "PropertySet",
+            "propertySetItems" : [
+              "NUTZUNG",
+              "Rastplatz "
+            ]
+          }
+        }
+      ],
+      "htmlPopupEnabled" : true,
+      "selectable" : true,
+      "featureCacheType" : "Session",
+      "displayFiltersType" : "ByScale",
+      "featureBlendingMode" : "Alpha",
+      "layerEffectsMode" : "Layer",
+      "labelClasses" : [
+        {
+          "type" : "CIMLabelClass",
+          "expressionTitle" : "Custom",
+          "expression" : "$feature.beschr",
+          "expressionEngine" : "Arcade",
+          "featuresToLabel" : "AllVisibleFeatures",
+          "maplexLabelPlacementProperties" : {
+            "type" : "CIMMaplexLabelPlacementProperties",
+            "featureType" : "Point",
+            "avoidPolygonHoles" : true,
+            "canOverrunFeature" : true,
+            "canPlaceLabelOutsidePolygon" : true,
+            "canRemoveOverlappingLabel" : true,
+            "canStackLabel" : true,
+            "centerLabelAnchorType" : "Symbol",
+            "connectionType" : "Unambiguous",
+            "constrainOffset" : "NoConstraint",
+            "contourAlignmentType" : "Page",
+            "contourLadderType" : "Straight",
+            "contourMaximumAngle" : 90,
+            "enableConnection" : true,
+            "enablePointPlacementPriorities" : true,
+            "featureWeight" : 0,
+            "fontHeightReductionLimit" : 4,
+            "fontHeightReductionStep" : 0.5,
+            "fontWidthReductionLimit" : 90,
+            "fontWidthReductionStep" : 5,
+            "graticuleAlignmentType" : "Straight",
+            "keyNumberGroupName" : "Default",
+            "labelBuffer" : 15,
+            "labelLargestPolygon" : true,
+            "labelPriority" : -1,
+            "labelStackingProperties" : {
+              "type" : "CIMMaplexLabelStackingProperties",
+              "stackAlignment" : "ChooseBest",
+              "maximumNumberOfLines" : 3,
+              "minimumNumberOfCharsPerLine" : 3,
+              "maximumNumberOfCharsPerLine" : 24,
+              "separators" : [
+                {
+                  "type" : "CIMMaplexStackingSeparator",
+                  "separator" : " ",
+                  "splitAfter" : true
+                },
+                {
+                  "type" : "CIMMaplexStackingSeparator",
+                  "separator" : ",",
+                  "visible" : true,
+                  "splitAfter" : true
+                }
+              ],
+              "trimStackingSeparators" : true
+            },
+            "lineFeatureType" : "General",
+            "linePlacementMethod" : "OffsetCurvedFromLine",
+            "maximumLabelOverrun" : 36,
+            "maximumLabelOverrunUnit" : "Point",
+            "minimumFeatureSizeUnit" : "Map",
+            "multiPartOption" : "OneLabelPerPart",
+            "offsetAlongLineProperties" : {
+              "type" : "CIMMaplexOffsetAlongLineProperties",
+              "placementMethod" : "BestPositionAlongLine",
+              "labelAnchorPoint" : "CenterOfLabel",
+              "distanceUnit" : "Percentage",
+              "useLineDirection" : true
+            },
+            "pointExternalZonePriorities" : {
+              "type" : "CIMMaplexExternalZonePriorities",
+              "aboveLeft" : 4,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerRight" : 3,
+              "belowRight" : 5,
+              "belowCenter" : 7,
+              "belowLeft" : 8,
+              "centerLeft" : 6
+            },
+            "pointPlacementMethod" : "EastOfPoint",
+            "polygonAnchorPointType" : "GeometricCenter",
+            "polygonBoundaryWeight" : 0,
+            "polygonExternalZones" : {
+              "type" : "CIMMaplexExternalZonePriorities",
+              "aboveLeft" : 4,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerRight" : 3,
+              "belowRight" : 5,
+              "belowCenter" : 7,
+              "belowLeft" : 8,
+              "centerLeft" : 6
+            },
+            "polygonFeatureType" : "General",
+            "polygonInternalZones" : {
+              "type" : "CIMMaplexInternalZonePriorities",
+              "center" : 1
+            },
+            "polygonPlacementMethod" : "CurvedInPolygon",
+            "primaryOffset" : 1,
+            "primaryOffsetUnit" : "Point",
+            "removeAmbiguousLabels" : "All",
+            "removeExtraWhiteSpace" : true,
+            "repetitionIntervalUnit" : "Point",
+            "rotationProperties" : {
+              "type" : "CIMMaplexRotationProperties",
+              "rotationType" : "Arithmetic",
+              "alignmentType" : "Straight"
+            },
+            "secondaryOffset" : 100,
+            "secondaryOffsetUnit" : "Percentage",
+            "strategyPriorities" : {
+              "type" : "CIMMaplexStrategyPriorities",
+              "stacking" : 1,
+              "overrun" : 2,
+              "fontCompression" : 3,
+              "fontReduction" : 4,
+              "abbreviation" : 5
+            },
+            "thinningDistanceUnit" : "Point",
+            "truncationMarkerCharacter" : ".",
+            "truncationMinimumLength" : 1,
+            "truncationPreferredCharacters" : "aeiou",
+            "truncationExcludedCharacters" : "0123456789",
+            "polygonAnchorPointPerimeterInsetUnit" : "Point"
+          },
+          "minimumScale" : 50000,
+          "name" : "Class 1",
+          "priority" : -1,
+          "standardLabelPlacementProperties" : {
+            "type" : "CIMStandardLabelPlacementProperties",
+            "featureType" : "Line",
+            "featureWeight" : "None",
+            "labelWeight" : "High",
+            "numLabelsOption" : "OneLabelPerName",
+            "lineLabelPosition" : {
+              "type" : "CIMStandardLineLabelPosition",
+              "above" : true,
+              "inLine" : true,
+              "parallel" : true
+            },
+            "lineLabelPriorities" : {
+              "type" : "CIMStandardLineLabelPriorities",
+              "aboveStart" : 3,
+              "aboveAlong" : 3,
+              "aboveEnd" : 3,
+              "centerStart" : 3,
+              "centerAlong" : 3,
+              "centerEnd" : 3,
+              "belowStart" : 3,
+              "belowAlong" : 3,
+              "belowEnd" : 3
+            },
+            "pointPlacementMethod" : "AroundPoint",
+            "pointPlacementPriorities" : {
+              "type" : "CIMStandardPointPlacementPriorities",
+              "aboveLeft" : 2,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerLeft" : 3,
+              "centerRight" : 2,
+              "belowLeft" : 3,
+              "belowCenter" : 3,
+              "belowRight" : 2
+            },
+            "rotationType" : "Arithmetic",
+            "polygonPlacementMethod" : "AlwaysHorizontal"
+          },
+          "textSymbol" : {
+            "type" : "CIMSymbolReference",
+            "symbol" : {
+              "type" : "CIMTextSymbol",
+              "blockProgression" : "TTB",
+              "callout" : {
+                "type" : "CIMBalloonCallout",
+                "balloonStyle" : "RoundedRectangle",
+                "backgroundSymbol" : {
+                  "type" : "CIMPolygonSymbol",
+                  "symbolLayers" : [
+                    {
+                      "type" : "CIMSolidFill",
+                      "enable" : true,
+                      "color" : {
+                        "type" : "CIMRGBColor",
+                        "values" : [
+                          255,
+                          255,
+                          255,
+                          100
+                        ]
+                      }
+                    }
+                  ],
+                  "angleAlignment" : "Map"
+                },
+                "margin" : {
+                  "type" : "CIMTextMargin",
+                  "left" : 1,
+                  "right" : 1,
+                  "top" : 1,
+                  "bottom" : 1
+                },
+                "fixedDartWidth" : 7,
+                "dartSymbol" : {
+                  "type" : "CIMPolygonSymbol",
+                  "symbolLayers" : [
+                    {
+                      "type" : "CIMSolidFill",
+                      "enable" : true,
+                      "color" : {
+                        "type" : "CIMRGBColor",
+                        "values" : [
+                          0,
+                          0,
+                          0,
+                          100
+                        ]
+                      }
+                    }
+                  ],
+                  "angleAlignment" : "Map"
+                }
+              },
+              "depth3D" : 1,
+              "extrapolateBaselines" : true,
+              "fontEffects" : "Normal",
+              "fontEncoding" : "Unicode",
+              "fontFamilyName" : "Tahoma",
+              "fontStyleName" : "Regular",
+              "fontType" : "Unspecified",
+              "haloSize" : 1,
+              "height" : 8,
+              "hinting" : "Default",
+              "horizontalAlignment" : "Left",
+              "kerning" : true,
+              "letterWidth" : 100,
+              "ligatures" : true,
+              "lineGapType" : "ExtraLeading",
+              "symbol" : {
+                "type" : "CIMPolygonSymbol",
+                "symbolLayers" : [
+                  {
+                    "type" : "CIMSolidFill",
+                    "enable" : true,
+                    "color" : {
+                      "type" : "CIMRGBColor",
+                      "values" : [
+                        0,
+                        0,
+                        0,
+                        100
+                      ]
+                    }
+                  }
+                ],
+                "angleAlignment" : "Map"
+              },
+              "symbol3DProperties" : {
+                "type" : "CIM3DSymbolProperties",
+                "dominantSizeAxis3D" : "Z",
+                "rotationOrder3D" : "YXZ",
+                "scaleZ" : 1,
+                "scaleY" : 1
+              },
+              "textCase" : "Normal",
+              "textDirection" : "LTR",
+              "verticalAlignment" : "Bottom",
+              "verticalGlyphOrientation" : "Right",
+              "wordSpacing" : 100,
+              "billboardMode3D" : "FaceNearPlane"
+            }
+          },
+          "useCodedValue" : true,
+          "visibility" : true,
+          "iD" : -1
+        }
+      ],
+      "labelVisibility" : true,
+      "renderer" : {
+        "type" : "CIMUniqueValueRenderer",
+        "sampleSize" : 10000,
+        "colorRamp" : {
+          "type" : "CIMRandomHSVColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "maxH" : 360,
+          "minS" : 15,
+          "maxS" : 30,
+          "minV" : 99,
+          "maxV" : 100,
+          "minAlpha" : 100,
+          "maxAlpha" : 100
+        },
+        "defaultLabel" : "<all other values>",
+        "defaultSymbol" : {
+          "type" : "CIMSymbolReference",
+          "symbol" : {
+            "type" : "CIMPointSymbol",
+            "symbolLayers" : [
+              {
+                "type" : "CIMVectorMarker",
+                "enable" : true,
+                "anchorPointUnits" : "Relative",
+                "dominantSizeAxis3D" : "Z",
+                "size" : 4,
+                "billboardMode3D" : "FaceNearPlane",
+                "frame" : {
+                  "xmin" : -2,
+                  "ymin" : -2,
+                  "xmax" : 2,
+                  "ymax" : 2
+                },
+                "markerGraphics" : [
+                  {
+                    "type" : "CIMMarkerGraphic",
+                    "geometry" : {
+                      "curveRings" : [
+                        [
+                          [
+                            1.2246467991473532e-16,
+                            2
+                          ],
+                          {
+                            "a" : [
+                              [
+                                1.2246467991473532e-16,
+                                2
+                              ],
+                              [
+                                6.0037636294980246e-15,
+                                0
+                              ],
+                              0,
+                              1
+                            ]
+                          }
+                        ]
+                      ]
+                    },
+                    "symbol" : {
+                      "type" : "CIMPolygonSymbol",
+                      "symbolLayers" : [
+                        {
+                          "type" : "CIMSolidStroke",
+                          "enable" : true,
+                          "capStyle" : "Round",
+                          "joinStyle" : "Round",
+                          "lineStyle3D" : "Strip",
+                          "miterLimit" : 10,
+                          "width" : 1,
+                          "height3D" : 1,
+                          "anchor3D" : "Center",
+                          "color" : {
+                            "type" : "CIMRGBColor",
+                            "values" : [
+                              0,
+                              0,
+                              0,
+                              100
+                            ]
+                          }
+                        },
+                        {
+                          "type" : "CIMSolidFill",
+                          "enable" : true,
+                          "color" : {
+                            "type" : "CIMRGBColor",
+                            "values" : [
+                              133,
+                              0,
+                              11,
+                              100
+                            ]
+                          }
+                        }
+                      ],
+                      "angleAlignment" : "Map"
+                    }
+                  }
+                ],
+                "respectFrame" : true
+              }
+            ],
+            "haloSize" : 1,
+            "scaleX" : 1,
+            "angleAlignment" : "Map"
+          }
+        },
+        "defaultSymbolPatch" : "Default",
+        "fields" : [
+          "nutzung"
+        ],
+        "groups" : [
+          {
+            "type" : "CIMUniqueValueGroup",
+            "classes" : [
+              {
+                "type" : "CIMUniqueValueClass",
+                "label" : "Stellplatz",
+                "patch" : "Default",
+                "symbol" : {
+                  "type" : "CIMSymbolReference",
+                  "symbol" : {
+                    "type" : "CIMPointSymbol",
+                    "symbolLayers" : [
+                      {
+                        "type" : "CIMVectorMarker",
+                        "enable" : true,
+                        "name" : "New_b5e373ca-dc72-43ab-9fc0-77d572516877",
+                        "colorLocked" : true,
+                        "anchorPoint" : {
+                          "x" : 0,
+                          "y" : -1.55,
+                          "z" : 0
+                        },
+                        "anchorPointUnits" : "Relative",
+                        "dominantSizeAxis3D" : "Y",
+                        "size" : 11,
+                        "billboardMode3D" : "FaceNearPlane",
+                        "frame" : {
+                          "xmin" : -5,
+                          "ymin" : -5,
+                          "xmax" : 5,
+                          "ymax" : 5
+                        },
+                        "markerGraphics" : [
+                          {
+                            "type" : "CIMMarkerGraphic",
+                            "geometry" : {
+                              "curveRings" : [
+                                [
+                                  [
+                                    0,
+                                    5
+                                  ],
+                                  {
+                                    "a" : [
+                                      [
+                                        0,
+                                        5
+                                      ],
+                                      [
+                                        1.1372578300082754e-14,
+                                        0
+                                      ],
+                                      0,
+                                      1
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol" : {
+                              "type" : "CIMPolygonSymbol",
+                              "symbolLayers" : [
+                                {
+                                  "type" : "CIMSolidFill",
+                                  "enable" : true,
+                                  "name" : "New_f4631f39-444d-471a-bf1f-765b412a4f68",
+                                  "color" : {
+                                    "type" : "CIMRGBColor",
+                                    "values" : [
+                                      0,
+                                      41,
+                                      240,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment" : "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally" : true,
+                        "respectFrame" : true
+                      },
+                      {
+                        "type" : "CIMVectorMarker",
+                        "enable" : true,
+                        "name" : "New_9d84be30-2483-4ac6-9d56-99edb64deb2c",
+                        "colorLocked" : true,
+                        "anchorPoint" : {
+                          "x" : 0,
+                          "y" : -0.5,
+                          "z" : 0
+                        },
+                        "anchorPointUnits" : "Relative",
+                        "dominantSizeAxis3D" : "Y",
+                        "size" : 24,
+                        "billboardMode3D" : "FaceNearPlane",
+                        "frame" : {
+                          "xmin" : -5,
+                          "ymin" : -2,
+                          "xmax" : 5,
+                          "ymax" : 15
+                        },
+                        "markerGraphics" : [
+                          {
+                            "type" : "CIMMarkerGraphic",
+                            "geometry" : {
+                              "curveRings" : [
+                                [
+                                  [
+                                    0,
+                                    -2
+                                  ],
+                                  {
+                                    "b" : [
+                                      [
+                                        -5,
+                                        10
+                                      ],
+                                      [
+                                        -1,
+                                        5
+                                      ],
+                                      [
+                                        -5,
+                                        7
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b" : [
+                                      [
+                                        0,
+                                        15
+                                      ],
+                                      [
+                                        -5,
+                                        13
+                                      ],
+                                      [
+                                        -3,
+                                        15
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b" : [
+                                      [
+                                        5,
+                                        10
+                                      ],
+                                      [
+                                        3,
+                                        15
+                                      ],
+                                      [
+                                        5,
+                                        13
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b" : [
+                                      [
+                                        0,
+                                        -2
+                                      ],
+                                      [
+                                        5,
+                                        7
+                                      ],
+                                      [
+                                        1,
+                                        5
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol" : {
+                              "type" : "CIMPolygonSymbol",
+                              "symbolLayers" : [
+                                {
+                                  "type" : "CIMSolidStroke",
+                                  "enable" : true,
+                                  "capStyle" : "Round",
+                                  "joinStyle" : "Round",
+                                  "lineStyle3D" : "Strip",
+                                  "miterLimit" : 10,
+                                  "width" : 0.5,
+                                  "height3D" : 1,
+                                  "anchor3D" : "Center",
+                                  "color" : {
+                                    "type" : "CIMRGBColor",
+                                    "values" : [
+                                      130,
+                                      130,
+                                      130,
+                                      100
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type" : "CIMSolidFill",
+                                  "enable" : true,
+                                  "color" : {
+                                    "type" : "CIMRGBColor",
+                                    "values" : [
+                                      255,
+                                      127,
+                                      127,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment" : "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally" : true,
+                        "respectFrame" : true
+                      }
+                    ],
+                    "haloSize" : 1,
+                    "scaleX" : 1,
+                    "angleAlignment" : "Display"
+                  }
+                },
+                "values" : [
+                  {
+                    "type" : "CIMUniqueValue",
+                    "fieldValues" : [
+                      "Stellplatz"
+                    ]
+                  }
+                ],
+                "visible" : true
+              },
+              {
+                "type" : "CIMUniqueValueClass",
+                "editable" : true,
+                "label" : "Park und Pool",
+                "patch" : "Default",
+                "symbol" : {
+                  "type" : "CIMSymbolReference",
+                  "symbol" : {
+                    "type" : "CIMPointSymbol",
+                    "symbolLayers" : [
+                      {
+                        "type" : "CIMVectorMarker",
+                        "enable" : true,
+                        "name" : "New_b2e9c1f8-3bae-48ed-b8f1-16940d02bc74",
+                        "colorLocked" : true,
+                        "anchorPoint" : {
+                          "x" : 0,
+                          "y" : -1.55,
+                          "z" : 0
+                        },
+                        "anchorPointUnits" : "Relative",
+                        "dominantSizeAxis3D" : "Y",
+                        "size" : 11,
+                        "billboardMode3D" : "FaceNearPlane",
+                        "frame" : {
+                          "xmin" : -5,
+                          "ymin" : -5,
+                          "xmax" : 5,
+                          "ymax" : 5
+                        },
+                        "markerGraphics" : [
+                          {
+                            "type" : "CIMMarkerGraphic",
+                            "geometry" : {
+                              "curveRings" : [
+                                [
+                                  [
+                                    0,
+                                    5
+                                  ],
+                                  {
+                                    "a" : [
+                                      [
+                                        0,
+                                        5
+                                      ],
+                                      [
+                                        1.1372578300082754e-14,
+                                        0
+                                      ],
+                                      0,
+                                      1
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol" : {
+                              "type" : "CIMPolygonSymbol",
+                              "symbolLayers" : [
+                                {
+                                  "type" : "CIMSolidFill",
+                                  "enable" : true,
+                                  "name" : "New_f4631f39-444d-471a-bf1f-765b412a4f68",
+                                  "color" : {
+                                    "type" : "CIMRGBColor",
+                                    "values" : [
+                                      0,
+                                      41,
+                                      240,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment" : "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally" : true,
+                        "respectFrame" : true
+                      },
+                      {
+                        "type" : "CIMVectorMarker",
+                        "enable" : true,
+                        "name" : "New_94dc5408-231d-4b9d-b717-94470c6fc4b2",
+                        "colorLocked" : true,
+                        "anchorPoint" : {
+                          "x" : 0,
+                          "y" : -0.5
+                        },
+                        "anchorPointUnits" : "Relative",
+                        "dominantSizeAxis3D" : "Y",
+                        "size" : 24,
+                        "billboardMode3D" : "FaceNearPlane",
+                        "frame" : {
+                          "xmin" : -5,
+                          "ymin" : -2,
+                          "xmax" : 5,
+                          "ymax" : 15
+                        },
+                        "markerGraphics" : [
+                          {
+                            "type" : "CIMMarkerGraphic",
+                            "geometry" : {
+                              "curveRings" : [
+                                [
+                                  [
+                                    0,
+                                    -2
+                                  ],
+                                  {
+                                    "b" : [
+                                      [
+                                        -5,
+                                        10
+                                      ],
+                                      [
+                                        -1,
+                                        5
+                                      ],
+                                      [
+                                        -5,
+                                        7
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b" : [
+                                      [
+                                        0,
+                                        15
+                                      ],
+                                      [
+                                        -5,
+                                        13
+                                      ],
+                                      [
+                                        -3,
+                                        15
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b" : [
+                                      [
+                                        5,
+                                        10
+                                      ],
+                                      [
+                                        3,
+                                        15
+                                      ],
+                                      [
+                                        5,
+                                        13
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b" : [
+                                      [
+                                        0,
+                                        -2
+                                      ],
+                                      [
+                                        5,
+                                        7
+                                      ],
+                                      [
+                                        1,
+                                        5
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol" : {
+                              "type" : "CIMPolygonSymbol",
+                              "symbolLayers" : [
+                                {
+                                  "type" : "CIMSolidStroke",
+                                  "enable" : true,
+                                  "capStyle" : "Round",
+                                  "joinStyle" : "Round",
+                                  "lineStyle3D" : "Strip",
+                                  "miterLimit" : 10,
+                                  "width" : 0.5,
+                                  "height3D" : 1,
+                                  "anchor3D" : "Center",
+                                  "color" : {
+                                    "type" : "CIMRGBColor",
+                                    "values" : [
+                                      130,
+                                      130,
+                                      130,
+                                      100
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type" : "CIMSolidFill",
+                                  "enable" : true,
+                                  "color" : {
+                                    "type" : "CIMRGBColor",
+                                    "values" : [
+                                      190,
+                                      210,
+                                      255,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment" : "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally" : true,
+                        "respectFrame" : true
+                      }
+                    ],
+                    "haloSize" : 1,
+                    "scaleX" : 1,
+                    "angleAlignment" : "Display"
+                  }
+                },
+                "values" : [
+                  {
+                    "type" : "CIMUniqueValue",
+                    "fieldValues" : [
+                      "Park und Pool"
+                    ]
+                  }
+                ],
+                "visible" : true
+              },
+              {
+                "type" : "CIMUniqueValueClass",
+                "editable" : true,
+                "label" : "Parkplatz",
+                "patch" : "Default",
+                "symbol" : {
+                  "type" : "CIMSymbolReference",
+                  "symbol" : {
+                    "type" : "CIMPointSymbol",
+                    "symbolLayers" : [
+                      {
+                        "type" : "CIMVectorMarker",
+                        "enable" : true,
+                        "name" : "New_402cc530-33c7-4411-9f2a-912756015a46",
+                        "colorLocked" : true,
+                        "anchorPoint" : {
+                          "x" : 0,
+                          "y" : 0,
+                          "z" : 0
+                        },
+                        "anchorPointUnits" : "Relative",
+                        "dominantSizeAxis3D" : "Y",
+                        "offsetY" : 17,
+                        "size" : 11,
+                        "billboardMode3D" : "FaceNearPlane",
+                        "frame" : {
+                          "xmin" : -5,
+                          "ymin" : -5,
+                          "xmax" : 5,
+                          "ymax" : 5
+                        },
+                        "markerGraphics" : [
+                          {
+                            "type" : "CIMMarkerGraphic",
+                            "geometry" : {
+                              "curveRings" : [
+                                [
+                                  [
+                                    0,
+                                    5
+                                  ],
+                                  {
+                                    "a" : [
+                                      [
+                                        0,
+                                        5
+                                      ],
+                                      [
+                                        1.1265137362215803e-14,
+                                        0
+                                      ],
+                                      0,
+                                      1
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol" : {
+                              "type" : "CIMPolygonSymbol",
+                              "symbolLayers" : [
+                                {
+                                  "type" : "CIMSolidFill",
+                                  "enable" : true,
+                                  "name" : "New_f4631f39-444d-471a-bf1f-765b412a4f68",
+                                  "color" : {
+                                    "type" : "CIMRGBColor",
+                                    "values" : [
+                                      0,
+                                      41,
+                                      240,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment" : "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally" : true,
+                        "respectFrame" : true
+                      },
+                      {
+                        "type" : "CIMVectorMarker",
+                        "enable" : true,
+                        "name" : "New_63a771a9-b0ba-48a5-8a10-b85f913a4cb2",
+                        "colorLocked" : true,
+                        "anchorPoint" : {
+                          "x" : 0,
+                          "y" : -0.5
+                        },
+                        "anchorPointUnits" : "Relative",
+                        "dominantSizeAxis3D" : "Y",
+                        "size" : 24,
+                        "billboardMode3D" : "FaceNearPlane",
+                        "frame" : {
+                          "xmin" : -5,
+                          "ymin" : -2,
+                          "xmax" : 5,
+                          "ymax" : 15
+                        },
+                        "markerGraphics" : [
+                          {
+                            "type" : "CIMMarkerGraphic",
+                            "geometry" : {
+                              "curveRings" : [
+                                [
+                                  [
+                                    0,
+                                    -2
+                                  ],
+                                  {
+                                    "b" : [
+                                      [
+                                        -5,
+                                        10
+                                      ],
+                                      [
+                                        -1,
+                                        5
+                                      ],
+                                      [
+                                        -5,
+                                        7
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b" : [
+                                      [
+                                        0,
+                                        15
+                                      ],
+                                      [
+                                        -5,
+                                        13
+                                      ],
+                                      [
+                                        -3,
+                                        15
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b" : [
+                                      [
+                                        5,
+                                        10
+                                      ],
+                                      [
+                                        3,
+                                        15
+                                      ],
+                                      [
+                                        5,
+                                        13
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b" : [
+                                      [
+                                        0,
+                                        -2
+                                      ],
+                                      [
+                                        5,
+                                        7
+                                      ],
+                                      [
+                                        1,
+                                        5
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol" : {
+                              "type" : "CIMPolygonSymbol",
+                              "symbolLayers" : [
+                                {
+                                  "type" : "CIMSolidStroke",
+                                  "enable" : true,
+                                  "capStyle" : "Round",
+                                  "joinStyle" : "Round",
+                                  "lineStyle3D" : "Strip",
+                                  "miterLimit" : 10,
+                                  "width" : 0.5,
+                                  "height3D" : 1,
+                                  "anchor3D" : "Center",
+                                  "color" : {
+                                    "type" : "CIMRGBColor",
+                                    "values" : [
+                                      130,
+                                      130,
+                                      130,
+                                      100
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type" : "CIMSolidFill",
+                                  "enable" : true,
+                                  "color" : {
+                                    "type" : "CIMRGBColor",
+                                    "values" : [
+                                      102,
+                                      119,
+                                      205,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment" : "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally" : true,
+                        "respectFrame" : true
+                      }
+                    ],
+                    "haloSize" : 1,
+                    "scaleX" : 1,
+                    "angleAlignment" : "Display"
+                  }
+                },
+                "values" : [
+                  {
+                    "type" : "CIMUniqueValue",
+                    "fieldValues" : [
+                      "Parkplatz"
+                    ]
+                  }
+                ],
+                "visible" : true
+              },
+              {
+                "type" : "CIMUniqueValueClass",
+                "editable" : true,
+                "label" : "Rastplatz",
+                "patch" : "Default",
+                "symbol" : {
+                  "type" : "CIMSymbolReference",
+                  "symbol" : {
+                    "type" : "CIMPointSymbol",
+                    "symbolLayers" : [
+                      {
+                        "type" : "CIMVectorMarker",
+                        "enable" : true,
+                        "name" : "New_981cf9bf-585e-4ddb-8149-38c86447831b",
+                        "colorLocked" : true,
+                        "anchorPoint" : {
+                          "x" : 0,
+                          "y" : 0,
+                          "z" : 0
+                        },
+                        "anchorPointUnits" : "Relative",
+                        "dominantSizeAxis3D" : "Y",
+                        "offsetY" : 17,
+                        "size" : 11,
+                        "billboardMode3D" : "FaceNearPlane",
+                        "frame" : {
+                          "xmin" : -5,
+                          "ymin" : -5,
+                          "xmax" : 5,
+                          "ymax" : 5
+                        },
+                        "markerGraphics" : [
+                          {
+                            "type" : "CIMMarkerGraphic",
+                            "geometry" : {
+                              "curveRings" : [
+                                [
+                                  [
+                                    0,
+                                    5
+                                  ],
+                                  {
+                                    "a" : [
+                                      [
+                                        0,
+                                        5
+                                      ],
+                                      [
+                                        9.1521322508324378e-15,
+                                        0
+                                      ],
+                                      0,
+                                      1
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol" : {
+                              "type" : "CIMPolygonSymbol",
+                              "symbolLayers" : [
+                                {
+                                  "type" : "CIMSolidFill",
+                                  "enable" : true,
+                                  "name" : "New_f4631f39-444d-471a-bf1f-765b412a4f68",
+                                  "color" : {
+                                    "type" : "CIMRGBColor",
+                                    "values" : [
+                                      0,
+                                      41,
+                                      240,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment" : "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally" : true,
+                        "respectFrame" : true
+                      },
+                      {
+                        "type" : "CIMVectorMarker",
+                        "enable" : true,
+                        "name" : "New_0892beed-cd7f-4aac-9961-7f438ab6bd0e",
+                        "colorLocked" : true,
+                        "anchorPoint" : {
+                          "x" : 0,
+                          "y" : -0.5
+                        },
+                        "anchorPointUnits" : "Relative",
+                        "dominantSizeAxis3D" : "Y",
+                        "size" : 24,
+                        "billboardMode3D" : "FaceNearPlane",
+                        "frame" : {
+                          "xmin" : -5,
+                          "ymin" : -2,
+                          "xmax" : 5,
+                          "ymax" : 15
+                        },
+                        "markerGraphics" : [
+                          {
+                            "type" : "CIMMarkerGraphic",
+                            "geometry" : {
+                              "curveRings" : [
+                                [
+                                  [
+                                    0,
+                                    -2
+                                  ],
+                                  {
+                                    "b" : [
+                                      [
+                                        -5,
+                                        10
+                                      ],
+                                      [
+                                        -1,
+                                        5
+                                      ],
+                                      [
+                                        -5,
+                                        7
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b" : [
+                                      [
+                                        0,
+                                        15
+                                      ],
+                                      [
+                                        -5,
+                                        13
+                                      ],
+                                      [
+                                        -3,
+                                        15
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b" : [
+                                      [
+                                        5,
+                                        10
+                                      ],
+                                      [
+                                        3,
+                                        15
+                                      ],
+                                      [
+                                        5,
+                                        13
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b" : [
+                                      [
+                                        0,
+                                        -2
+                                      ],
+                                      [
+                                        5,
+                                        7
+                                      ],
+                                      [
+                                        1,
+                                        5
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol" : {
+                              "type" : "CIMPolygonSymbol",
+                              "symbolLayers" : [
+                                {
+                                  "type" : "CIMSolidStroke",
+                                  "enable" : true,
+                                  "capStyle" : "Round",
+                                  "joinStyle" : "Round",
+                                  "lineStyle3D" : "Strip",
+                                  "miterLimit" : 10,
+                                  "width" : 0.5,
+                                  "height3D" : 1,
+                                  "anchor3D" : "Center",
+                                  "color" : {
+                                    "type" : "CIMRGBColor",
+                                    "values" : [
+                                      130,
+                                      130,
+                                      130,
+                                      100
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type" : "CIMSolidFill",
+                                  "enable" : true,
+                                  "color" : {
+                                    "type" : "CIMRGBColor",
+                                    "values" : [
+                                      255,
+                                      219.93000000000001,
+                                      0,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment" : "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally" : true,
+                        "respectFrame" : true
+                      }
+                    ],
+                    "haloSize" : 1,
+                    "scaleX" : 1,
+                    "angleAlignment" : "Display"
+                  }
+                },
+                "values" : [
+                  {
+                    "type" : "CIMUniqueValue",
+                    "fieldValues" : [
+                      "Rastplatz"
+                    ]
+                  }
+                ],
+                "visible" : true
+              }
+            ],
+            "heading" : "Nutzung"
+          }
+        ],
+        "isDefaultSymbolVisible" : true,
+        "polygonSymbolColorTarget" : "Fill"
+      },
+      "scaleSymbols" : true,
+      "snappable" : true
+    }
+  ],
+  "binaryReferences" : [
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/b41210729d2bf5bb42c4393b2056b587.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"de\"><Esri><CreaDate>20260120</CreaDate><CreaTime>09241100</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Parkplätze</resTitle></idCitation><idAbs>parkpl_2025</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
+    }
+  ],
+  "rGBColorProfile" : "sRGB IEC61966-2.1",
+  "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2",
+  "elevationSurfaceLayerDefinitions" : [
+    {
+      "type" : "CIMElevationSurfaceLayer",
+      "name" : "Ground",
+      "uRI" : "CIMPATH=Map/4be32e97315a4e45b7da6df7af90191d.json",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "useSourceMetadata" : true,
+      "description" : "Ground",
+      "expanded" : true,
+      "layerType" : "Operational",
+      "showLegends" : false,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "allowDrapingOnIntegratedMesh" : true,
+      "elevationMode" : "BaseGlobeSurface",
+      "verticalExaggeration" : 1,
+      "color" : {
+        "type" : "CIMRGBColor",
+        "values" : [
+          255,
+          255,
+          255,
+          100
+        ]
+      },
+      "surfaceTINShadingMode" : "Smooth"
+    }
+  ]
+}

--- a/tests/testdata/point/point_textSymbol_marker.lyrx
+++ b/tests/testdata/point/point_textSymbol_marker.lyrx
@@ -1,0 +1,1839 @@
+{
+  "type": "CIMLayerDocument",
+  "version": "3.4.0",
+  "build": 0,
+  "layers": [
+    "CIMPATH=Map/Parkpl_tze.json"
+  ],
+  "layerDefinitions": [
+    {
+      "type": "CIMFeatureLayer",
+      "name": "Parkplätze",
+      "uRI": "CIMPATH=Map/Parkpl_tze.json",
+      "sourceModifiedTime": {
+        "type": "TimeInstant",
+        "start": -62135596800000
+      },
+      "metadataURI": "CIMPATH=Metadata/e3a1e669e361bec666b7e4c5bf42c629.xml",
+      "useSourceMetadata": true,
+      "description": "parkpl_2025",
+      "layerElevation": {
+        "type": "CIMLayerElevationSurface",
+        "elevationSurfaceLayerURI": "CIMPATH=Map/b9f13348d94647a3bbd032e195c420a4.json"
+      },
+      "expanded": true,
+      "layerType": "Operational",
+      "showLegends": true,
+      "visibility": true,
+      "displayCacheType": "Permanent",
+      "maxDisplayCacheAge": 5,
+      "showPopups": true,
+      "serviceLayerID": -1,
+      "refreshRate": -1,
+      "refreshRateUnit": "esriTimeUnitsSeconds",
+      "blendingMode": "Alpha",
+      "allowDrapingOnIntegratedMesh": true,
+      "autoGenerateFeatureTemplates": true,
+      "featureElevationExpression": "0",
+      "featureTable": {
+        "type": "CIMFeatureTable",
+        "displayField": "ck",
+        "editable": true,
+        "fieldDescriptions": [
+          {
+            "type": "CIMFieldDescription",
+            "alias": "ck",
+            "fieldName": "ck",
+            "visible": true,
+            "searchMode": "Exact"
+          },
+          {
+            "type": "CIMFieldDescription",
+            "alias": "beschr",
+            "fieldName": "beschr",
+            "visible": true,
+            "searchMode": "Exact"
+          },
+          {
+            "type": "CIMFieldDescription",
+            "alias": "Shape",
+            "fieldName": "Shape",
+            "visible": true,
+            "searchMode": "Exact"
+          },
+          {
+            "type": "CIMFieldDescription",
+            "alias": "nutzung",
+            "fieldName": "nutzung",
+            "visible": true,
+            "searchMode": "Exact"
+          },
+          {
+            "type": "CIMFieldDescription",
+            "alias": "Eigentuemer",
+            "fieldName": "Eigentuemer",
+            "visible": true,
+            "searchMode": "Exact"
+          },
+          {
+            "type": "CIMFieldDescription",
+            "alias": "Bemerkungen",
+            "fieldName": "Bemerkungen",
+            "visible": true,
+            "searchMode": "Exact"
+          },
+          {
+            "type": "CIMFieldDescription",
+            "alias": "Anzahl_Parkpletze",
+            "fieldName": "Anzahl_Parkplaetze",
+            "numberFormat": {
+              "type": "CIMNumericFormat",
+              "alignmentOption": "esriAlignRight",
+              "alignmentWidth": 0,
+              "roundingOption": "esriRoundNumberOfDecimals",
+              "roundingValue": 0
+            },
+            "visible": true,
+            "searchMode": "Exact"
+          }
+        ],
+        "dataConnection": {
+          "type": "CIMStandardDataConnection",
+          "workspaceConnectionString": "",
+          "workspaceFactory": "SDE",
+          "dataset": "AGIS.atb_parkpl",
+          "datasetType": "esriDTFeatureClass"
+        },
+        "studyAreaSpatialRel": "esriSpatialRelUndefined",
+        "searchOrder": "esriSearchOrderSpatial"
+      },
+      "featureTemplates": [
+        {
+          "type": "CIMRowTemplate",
+          "name": "Parkplatz ",
+          "defaultValues": {
+            "type": "PropertySet",
+            "propertySetItems": [
+              "NUTZUNG",
+              "Parkplatz "
+            ]
+          }
+        },
+        {
+          "type": "CIMRowTemplate",
+          "name": "Stellplatz",
+          "defaultValues": {
+            "type": "PropertySet",
+            "propertySetItems": [
+              "NUTZUNG",
+              "Stellplatz"
+            ]
+          }
+        },
+        {
+          "type": "CIMRowTemplate",
+          "name": "Rastplatz ",
+          "defaultValues": {
+            "type": "PropertySet",
+            "propertySetItems": [
+              "NUTZUNG",
+              "Rastplatz "
+            ]
+          }
+        }
+      ],
+      "htmlPopupEnabled": true,
+      "selectable": true,
+      "featureCacheType": "Session",
+      "displayFiltersType": "ByScale",
+      "featureBlendingMode": "Alpha",
+      "layerEffectsMode": "Layer",
+      "labelClasses": [
+        {
+          "type": "CIMLabelClass",
+          "expressionTitle": "Custom",
+          "expression": "$feature.beschr",
+          "expressionEngine": "Arcade",
+          "featuresToLabel": "AllVisibleFeatures",
+          "maplexLabelPlacementProperties": {
+            "type": "CIMMaplexLabelPlacementProperties",
+            "featureType": "Point",
+            "avoidPolygonHoles": true,
+            "canOverrunFeature": true,
+            "canPlaceLabelOutsidePolygon": true,
+            "canRemoveOverlappingLabel": true,
+            "canStackLabel": true,
+            "centerLabelAnchorType": "Symbol",
+            "connectionType": "Unambiguous",
+            "constrainOffset": "NoConstraint",
+            "contourAlignmentType": "Page",
+            "contourLadderType": "Straight",
+            "contourMaximumAngle": 90,
+            "enableConnection": true,
+            "enablePointPlacementPriorities": true,
+            "featureWeight": 0,
+            "fontHeightReductionLimit": 4,
+            "fontHeightReductionStep": 0.5,
+            "fontWidthReductionLimit": 90,
+            "fontWidthReductionStep": 5,
+            "graticuleAlignmentType": "Straight",
+            "keyNumberGroupName": "Default",
+            "labelBuffer": 15,
+            "labelLargestPolygon": true,
+            "labelPriority": -1,
+            "labelStackingProperties": {
+              "type": "CIMMaplexLabelStackingProperties",
+              "stackAlignment": "ChooseBest",
+              "maximumNumberOfLines": 3,
+              "minimumNumberOfCharsPerLine": 3,
+              "maximumNumberOfCharsPerLine": 24,
+              "separators": [
+                {
+                  "type": "CIMMaplexStackingSeparator",
+                  "separator": " ",
+                  "splitAfter": true
+                },
+                {
+                  "type": "CIMMaplexStackingSeparator",
+                  "separator": ",",
+                  "visible": true,
+                  "splitAfter": true
+                }
+              ],
+              "trimStackingSeparators": true
+            },
+            "lineFeatureType": "General",
+            "linePlacementMethod": "OffsetCurvedFromLine",
+            "maximumLabelOverrun": 36,
+            "maximumLabelOverrunUnit": "Point",
+            "minimumFeatureSizeUnit": "Map",
+            "multiPartOption": "OneLabelPerPart",
+            "offsetAlongLineProperties": {
+              "type": "CIMMaplexOffsetAlongLineProperties",
+              "placementMethod": "BestPositionAlongLine",
+              "labelAnchorPoint": "CenterOfLabel",
+              "distanceUnit": "Percentage",
+              "useLineDirection": true
+            },
+            "pointExternalZonePriorities": {
+              "type": "CIMMaplexExternalZonePriorities",
+              "aboveLeft": 4,
+              "aboveCenter": 2,
+              "aboveRight": 1,
+              "centerRight": 3,
+              "belowRight": 5,
+              "belowCenter": 7,
+              "belowLeft": 8,
+              "centerLeft": 6
+            },
+            "pointPlacementMethod": "EastOfPoint",
+            "polygonAnchorPointType": "GeometricCenter",
+            "polygonBoundaryWeight": 0,
+            "polygonExternalZones": {
+              "type": "CIMMaplexExternalZonePriorities",
+              "aboveLeft": 4,
+              "aboveCenter": 2,
+              "aboveRight": 1,
+              "centerRight": 3,
+              "belowRight": 5,
+              "belowCenter": 7,
+              "belowLeft": 8,
+              "centerLeft": 6
+            },
+            "polygonFeatureType": "General",
+            "polygonInternalZones": {
+              "type": "CIMMaplexInternalZonePriorities",
+              "center": 1
+            },
+            "polygonPlacementMethod": "CurvedInPolygon",
+            "primaryOffset": 1,
+            "primaryOffsetUnit": "Point",
+            "removeAmbiguousLabels": "All",
+            "removeExtraWhiteSpace": true,
+            "repetitionIntervalUnit": "Point",
+            "rotationProperties": {
+              "type": "CIMMaplexRotationProperties",
+              "rotationType": "Arithmetic",
+              "alignmentType": "Straight"
+            },
+            "secondaryOffset": 100,
+            "secondaryOffsetUnit": "Percentage",
+            "strategyPriorities": {
+              "type": "CIMMaplexStrategyPriorities",
+              "stacking": 1,
+              "overrun": 2,
+              "fontCompression": 3,
+              "fontReduction": 4,
+              "abbreviation": 5
+            },
+            "thinningDistanceUnit": "Point",
+            "truncationMarkerCharacter": ".",
+            "truncationMinimumLength": 1,
+            "truncationPreferredCharacters": "aeiou",
+            "truncationExcludedCharacters": "0123456789",
+            "polygonAnchorPointPerimeterInsetUnit": "Point"
+          },
+          "minimumScale": 50000,
+          "name": "Class 1",
+          "priority": -1,
+          "standardLabelPlacementProperties": {
+            "type": "CIMStandardLabelPlacementProperties",
+            "featureType": "Line",
+            "featureWeight": "None",
+            "labelWeight": "High",
+            "numLabelsOption": "OneLabelPerName",
+            "lineLabelPosition": {
+              "type": "CIMStandardLineLabelPosition",
+              "above": true,
+              "inLine": true,
+              "parallel": true
+            },
+            "lineLabelPriorities": {
+              "type": "CIMStandardLineLabelPriorities",
+              "aboveStart": 3,
+              "aboveAlong": 3,
+              "aboveEnd": 3,
+              "centerStart": 3,
+              "centerAlong": 3,
+              "centerEnd": 3,
+              "belowStart": 3,
+              "belowAlong": 3,
+              "belowEnd": 3
+            },
+            "pointPlacementMethod": "AroundPoint",
+            "pointPlacementPriorities": {
+              "type": "CIMStandardPointPlacementPriorities",
+              "aboveLeft": 2,
+              "aboveCenter": 2,
+              "aboveRight": 1,
+              "centerLeft": 3,
+              "centerRight": 2,
+              "belowLeft": 3,
+              "belowCenter": 3,
+              "belowRight": 2
+            },
+            "rotationType": "Arithmetic",
+            "polygonPlacementMethod": "AlwaysHorizontal"
+          },
+          "textSymbol": {
+            "type": "CIMSymbolReference",
+            "symbol": {
+              "type": "CIMTextSymbol",
+              "blockProgression": "TTB",
+              "callout": {
+                "type": "CIMBalloonCallout",
+                "balloonStyle": "RoundedRectangle",
+                "backgroundSymbol": {
+                  "type": "CIMPolygonSymbol",
+                  "symbolLayers": [
+                    {
+                      "type": "CIMSolidFill",
+                      "enable": true,
+                      "color": {
+                        "type": "CIMRGBColor",
+                        "values": [
+                          255,
+                          255,
+                          255,
+                          100
+                        ]
+                      }
+                    }
+                  ],
+                  "angleAlignment": "Map"
+                },
+                "margin": {
+                  "type": "CIMTextMargin",
+                  "left": 1,
+                  "right": 1,
+                  "top": 1,
+                  "bottom": 1
+                },
+                "fixedDartWidth": 7,
+                "dartSymbol": {
+                  "type": "CIMPolygonSymbol",
+                  "symbolLayers": [
+                    {
+                      "type": "CIMSolidFill",
+                      "enable": true,
+                      "color": {
+                        "type": "CIMRGBColor",
+                        "values": [
+                          0,
+                          0,
+                          0,
+                          100
+                        ]
+                      }
+                    }
+                  ],
+                  "angleAlignment": "Map"
+                }
+              },
+              "depth3D": 1,
+              "extrapolateBaselines": true,
+              "fontEffects": "Normal",
+              "fontEncoding": "Unicode",
+              "fontFamilyName": "Tahoma",
+              "fontStyleName": "Regular",
+              "fontType": "Unspecified",
+              "haloSize": 1,
+              "height": 8,
+              "hinting": "Default",
+              "horizontalAlignment": "Left",
+              "kerning": true,
+              "letterWidth": 100,
+              "ligatures": true,
+              "lineGapType": "ExtraLeading",
+              "symbol": {
+                "type": "CIMPolygonSymbol",
+                "symbolLayers": [
+                  {
+                    "type": "CIMSolidFill",
+                    "enable": true,
+                    "color": {
+                      "type": "CIMRGBColor",
+                      "values": [
+                        0,
+                        0,
+                        0,
+                        100
+                      ]
+                    }
+                  }
+                ],
+                "angleAlignment": "Map"
+              },
+              "symbol3DProperties": {
+                "type": "CIM3DSymbolProperties",
+                "dominantSizeAxis3D": "Z",
+                "rotationOrder3D": "YXZ",
+                "scaleZ": 1,
+                "scaleY": 1
+              },
+              "textCase": "Normal",
+              "textDirection": "LTR",
+              "verticalAlignment": "Bottom",
+              "verticalGlyphOrientation": "Right",
+              "wordSpacing": 100,
+              "billboardMode3D": "FaceNearPlane"
+            }
+          },
+          "useCodedValue": true,
+          "visibility": true,
+          "iD": -1
+        }
+      ],
+      "labelVisibility": true,
+      "renderer": {
+        "type": "CIMUniqueValueRenderer",
+        "sampleSize": 10000,
+        "colorRamp": {
+          "type": "CIMRandomHSVColorRamp",
+          "colorSpace": {
+            "type": "CIMICCColorSpace",
+            "url": "Default RGB"
+          },
+          "maxH": 360,
+          "minS": 15,
+          "maxS": 30,
+          "minV": 99,
+          "maxV": 100,
+          "minAlpha": 100,
+          "maxAlpha": 100
+        },
+        "defaultLabel": "<all other values>",
+        "defaultSymbol": {
+          "type": "CIMSymbolReference",
+          "symbol": {
+            "type": "CIMPointSymbol",
+            "symbolLayers": [
+              {
+                "type": "CIMVectorMarker",
+                "enable": true,
+                "anchorPointUnits": "Relative",
+                "dominantSizeAxis3D": "Z",
+                "size": 4,
+                "billboardMode3D": "FaceNearPlane",
+                "frame": {
+                  "xmin": -2,
+                  "ymin": -2,
+                  "xmax": 2,
+                  "ymax": 2
+                },
+                "markerGraphics": [
+                  {
+                    "type": "CIMMarkerGraphic",
+                    "geometry": {
+                      "curveRings": [
+                        [
+                          [
+                            1.2246467991473532E-16,
+                            2
+                          ],
+                          {
+                            "a": [
+                              [
+                                1.2246467991473532E-16,
+                                2
+                              ],
+                              [
+                                5.072608834651119E-15,
+                                0
+                              ],
+                              0,
+                              1
+                            ]
+                          }
+                        ]
+                      ]
+                    },
+                    "symbol": {
+                      "type": "CIMPolygonSymbol",
+                      "symbolLayers": [
+                        {
+                          "type": "CIMSolidStroke",
+                          "enable": true,
+                          "capStyle": "Round",
+                          "joinStyle": "Round",
+                          "lineStyle3D": "Strip",
+                          "miterLimit": 10,
+                          "width": 1,
+                          "height3D": 1,
+                          "anchor3D": "Center",
+                          "color": {
+                            "type": "CIMRGBColor",
+                            "values": [
+                              0,
+                              0,
+                              0,
+                              100
+                            ]
+                          }
+                        },
+                        {
+                          "type": "CIMSolidFill",
+                          "enable": true,
+                          "color": {
+                            "type": "CIMRGBColor",
+                            "values": [
+                              133,
+                              0,
+                              11,
+                              100
+                            ]
+                          }
+                        }
+                      ],
+                      "angleAlignment": "Map"
+                    }
+                  }
+                ],
+                "respectFrame": true
+              }
+            ],
+            "haloSize": 1,
+            "scaleX": 1,
+            "angleAlignment": "Map"
+          }
+        },
+        "defaultSymbolPatch": "Default",
+        "fields": [
+          "nutzung"
+        ],
+        "groups": [
+          {
+            "type": "CIMUniqueValueGroup",
+            "classes": [
+              {
+                "type": "CIMUniqueValueClass",
+                "label": "Stellplatz",
+                "patch": "Default",
+                "symbol": {
+                  "type": "CIMSymbolReference",
+                  "symbol": {
+                    "type": "CIMPointSymbol",
+                    "symbolLayers": [
+                      {
+                        "type": "CIMVectorMarker",
+                        "enable": true,
+                        "name": "New_b5e373ca-dc72-43ab-9fc0-77d572516877",
+                        "anchorPoint": {
+                          "x": -0.06,
+                          "y": -2.5,
+                          "z": 0
+                        },
+                        "anchorPointUnits": "Relative",
+                        "dominantSizeAxis3D": "Y",
+                        "size": 7,
+                        "billboardMode3D": "FaceNearPlane",
+                        "frame": {
+                          "xmin": -5,
+                          "ymin": -5,
+                          "xmax": 5,
+                          "ymax": 5
+                        },
+                        "markerGraphics": [
+                          {
+                            "type": "CIMMarkerGraphic",
+                            "geometry": {
+                              "x": 0,
+                              "y": 0
+                            },
+                            "symbol": {
+                              "type": "CIMTextSymbol",
+                              "blockProgression": "TTB",
+                              "depth3D": 1,
+                              "extrapolateBaselines": true,
+                              "fontEffects": "Normal",
+                              "fontEncoding": "Unicode",
+                              "fontFamilyName": "Tahoma",
+                              "fontStyleName": "Bold",
+                              "fontType": "Unspecified",
+                              "haloSize": 1,
+                              "height": 10,
+                              "hinting": "Default",
+                              "horizontalAlignment": "Center",
+                              "kerning": true,
+                              "letterWidth": 100,
+                              "ligatures": true,
+                              "lineGapType": "ExtraLeading",
+                              "symbol": {
+                                "type": "CIMPolygonSymbol",
+                                "symbolLayers": [
+                                  {
+                                    "type": "CIMSolidFill",
+                                    "enable": true,
+                                    "color": {
+                                      "type": "CIMRGBColor",
+                                      "values": [
+                                        255,
+                                        255,
+                                        255,
+                                        100
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "angleAlignment": "Map"
+                              },
+                              "symbol3DProperties": {
+                                "type": "CIM3DSymbolProperties",
+                                "dominantSizeAxis3D": "Z",
+                                "rotationOrder3D": "YXZ",
+                                "scaleZ": 1,
+                                "scaleY": 1
+                              },
+                              "textCase": "Normal",
+                              "textDirection": "LTR",
+                              "verticalAlignment": "Center",
+                              "verticalGlyphOrientation": "Right",
+                              "wordSpacing": 100,
+                              "billboardMode3D": "FaceNearPlane"
+                            },
+                            "textString": "P"
+                          }
+                        ],
+                        "scaleSymbolsProportionally": true,
+                        "respectFrame": true
+                      },
+                      {
+                        "type": "CIMVectorMarker",
+                        "enable": true,
+                        "name": "New_9d84be30-2483-4ac6-9d56-99edb64deb2c",
+                        "colorLocked": true,
+                        "anchorPoint": {
+                          "x": 0,
+                          "y": -1.55,
+                          "z": 0
+                        },
+                        "anchorPointUnits": "Relative",
+                        "dominantSizeAxis3D": "Y",
+                        "size": 11,
+                        "billboardMode3D": "FaceNearPlane",
+                        "frame": {
+                          "xmin": -5,
+                          "ymin": -5,
+                          "xmax": 5,
+                          "ymax": 5
+                        },
+                        "markerGraphics": [
+                          {
+                            "type": "CIMMarkerGraphic",
+                            "geometry": {
+                              "curveRings": [
+                                [
+                                  [
+                                    0,
+                                    5
+                                  ],
+                                  {
+                                    "a": [
+                                      [
+                                        0,
+                                        5
+                                      ],
+                                      [
+                                        8.00609558025149E-15,
+                                        0
+                                      ],
+                                      0,
+                                      1
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol": {
+                              "type": "CIMPolygonSymbol",
+                              "symbolLayers": [
+                                {
+                                  "type": "CIMSolidFill",
+                                  "enable": true,
+                                  "name": "New_f4631f39-444d-471a-bf1f-765b412a4f68",
+                                  "color": {
+                                    "type": "CIMRGBColor",
+                                    "values": [
+                                      0,
+                                      41,
+                                      240,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment": "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally": true,
+                        "respectFrame": true
+                      },
+                      {
+                        "type": "CIMVectorMarker",
+                        "enable": true,
+                        "colorLocked": true,
+                        "anchorPoint": {
+                          "x": 0,
+                          "y": -0.5,
+                          "z": 0
+                        },
+                        "anchorPointUnits": "Relative",
+                        "dominantSizeAxis3D": "Y",
+                        "size": 24,
+                        "billboardMode3D": "FaceNearPlane",
+                        "frame": {
+                          "xmin": -5,
+                          "ymin": -2,
+                          "xmax": 5,
+                          "ymax": 15
+                        },
+                        "markerGraphics": [
+                          {
+                            "type": "CIMMarkerGraphic",
+                            "geometry": {
+                              "curveRings": [
+                                [
+                                  [
+                                    0,
+                                    -2
+                                  ],
+                                  {
+                                    "b": [
+                                      [
+                                        -5,
+                                        10
+                                      ],
+                                      [
+                                        -1,
+                                        5
+                                      ],
+                                      [
+                                        -5,
+                                        7
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b": [
+                                      [
+                                        0,
+                                        15
+                                      ],
+                                      [
+                                        -5,
+                                        13
+                                      ],
+                                      [
+                                        -3,
+                                        15
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b": [
+                                      [
+                                        5,
+                                        10
+                                      ],
+                                      [
+                                        3,
+                                        15
+                                      ],
+                                      [
+                                        5,
+                                        13
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b": [
+                                      [
+                                        0,
+                                        -2
+                                      ],
+                                      [
+                                        5,
+                                        7
+                                      ],
+                                      [
+                                        1,
+                                        5
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol": {
+                              "type": "CIMPolygonSymbol",
+                              "symbolLayers": [
+                                {
+                                  "type": "CIMSolidStroke",
+                                  "enable": true,
+                                  "capStyle": "Round",
+                                  "joinStyle": "Round",
+                                  "lineStyle3D": "Strip",
+                                  "miterLimit": 10,
+                                  "width": 0.5,
+                                  "height3D": 1,
+                                  "anchor3D": "Center",
+                                  "color": {
+                                    "type": "CIMRGBColor",
+                                    "values": [
+                                      255,
+                                      255,
+                                      255,
+                                      100
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type": "CIMSolidFill",
+                                  "enable": true,
+                                  "color": {
+                                    "type": "CIMRGBColor",
+                                    "values": [
+                                      255,
+                                      127,
+                                      127,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment": "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally": true,
+                        "respectFrame": true
+                      }
+                    ],
+                    "haloSize": 1,
+                    "scaleX": 1,
+                    "angleAlignment": "Display"
+                  }
+                },
+                "values": [
+                  {
+                    "type": "CIMUniqueValue",
+                    "fieldValues": [
+                      "Stellplatz"
+                    ]
+                  }
+                ],
+                "visible": true
+              },
+              {
+                "type": "CIMUniqueValueClass",
+                "editable": true,
+                "label": "Park und Pool",
+                "patch": "Default",
+                "symbol": {
+                  "type": "CIMSymbolReference",
+                  "symbol": {
+                    "type": "CIMPointSymbol",
+                    "symbolLayers": [
+                      {
+                        "type": "CIMVectorMarker",
+                        "enable": true,
+                        "name": "New_b2e9c1f8-3bae-48ed-b8f1-16940d02bc74",
+                        "anchorPoint": {
+                          "x": -0.06,
+                          "y": -2.5,
+                          "z": 0
+                        },
+                        "anchorPointUnits": "Relative",
+                        "dominantSizeAxis3D": "Y",
+                        "size": 7,
+                        "billboardMode3D": "FaceNearPlane",
+                        "frame": {
+                          "xmin": -5,
+                          "ymin": -5,
+                          "xmax": 5,
+                          "ymax": 5
+                        },
+                        "markerGraphics": [
+                          {
+                            "type": "CIMMarkerGraphic",
+                            "geometry": {
+                              "x": 0,
+                              "y": 0
+                            },
+                            "symbol": {
+                              "type": "CIMTextSymbol",
+                              "blockProgression": "TTB",
+                              "depth3D": 1,
+                              "extrapolateBaselines": true,
+                              "fontEffects": "Normal",
+                              "fontEncoding": "Unicode",
+                              "fontFamilyName": "Tahoma",
+                              "fontStyleName": "Bold",
+                              "fontType": "Unspecified",
+                              "haloSize": 1,
+                              "height": 10,
+                              "hinting": "Default",
+                              "horizontalAlignment": "Center",
+                              "kerning": true,
+                              "letterWidth": 100,
+                              "ligatures": true,
+                              "lineGapType": "ExtraLeading",
+                              "symbol": {
+                                "type": "CIMPolygonSymbol",
+                                "symbolLayers": [
+                                  {
+                                    "type": "CIMSolidFill",
+                                    "enable": true,
+                                    "color": {
+                                      "type": "CIMRGBColor",
+                                      "values": [
+                                        255,
+                                        255,
+                                        255,
+                                        100
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "angleAlignment": "Map"
+                              },
+                              "symbol3DProperties": {
+                                "type": "CIM3DSymbolProperties",
+                                "dominantSizeAxis3D": "Z",
+                                "rotationOrder3D": "YXZ",
+                                "scaleZ": 1,
+                                "scaleY": 1
+                              },
+                              "textCase": "Normal",
+                              "textDirection": "LTR",
+                              "verticalAlignment": "Center",
+                              "verticalGlyphOrientation": "Right",
+                              "wordSpacing": 100,
+                              "billboardMode3D": "FaceNearPlane"
+                            },
+                            "textString": "P"
+                          }
+                        ],
+                        "scaleSymbolsProportionally": true,
+                        "respectFrame": true
+                      },
+                      {
+                        "type": "CIMVectorMarker",
+                        "enable": true,
+                        "name": "New_94dc5408-231d-4b9d-b717-94470c6fc4b2",
+                        "colorLocked": true,
+                        "anchorPoint": {
+                          "x": 0,
+                          "y": -1.55,
+                          "z": 0
+                        },
+                        "anchorPointUnits": "Relative",
+                        "dominantSizeAxis3D": "Y",
+                        "size": 11,
+                        "billboardMode3D": "FaceNearPlane",
+                        "frame": {
+                          "xmin": -5,
+                          "ymin": -5,
+                          "xmax": 5,
+                          "ymax": 5
+                        },
+                        "markerGraphics": [
+                          {
+                            "type": "CIMMarkerGraphic",
+                            "geometry": {
+                              "curveRings": [
+                                [
+                                  [
+                                    0,
+                                    5
+                                  ],
+                                  {
+                                    "a": [
+                                      [
+                                        0,
+                                        5
+                                      ],
+                                      [
+                                        8.00609558025149E-15,
+                                        0
+                                      ],
+                                      0,
+                                      1
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol": {
+                              "type": "CIMPolygonSymbol",
+                              "symbolLayers": [
+                                {
+                                  "type": "CIMSolidFill",
+                                  "enable": true,
+                                  "name": "New_f4631f39-444d-471a-bf1f-765b412a4f68",
+                                  "color": {
+                                    "type": "CIMRGBColor",
+                                    "values": [
+                                      0,
+                                      41,
+                                      240,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment": "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally": true,
+                        "respectFrame": true
+                      },
+                      {
+                        "type": "CIMVectorMarker",
+                        "enable": true,
+                        "colorLocked": true,
+                        "anchorPoint": {
+                          "x": 0,
+                          "y": -0.5
+                        },
+                        "anchorPointUnits": "Relative",
+                        "dominantSizeAxis3D": "Y",
+                        "size": 24,
+                        "billboardMode3D": "FaceNearPlane",
+                        "frame": {
+                          "xmin": -5,
+                          "ymin": -2,
+                          "xmax": 5,
+                          "ymax": 15
+                        },
+                        "markerGraphics": [
+                          {
+                            "type": "CIMMarkerGraphic",
+                            "geometry": {
+                              "curveRings": [
+                                [
+                                  [
+                                    0,
+                                    -2
+                                  ],
+                                  {
+                                    "b": [
+                                      [
+                                        -5,
+                                        10
+                                      ],
+                                      [
+                                        -1,
+                                        5
+                                      ],
+                                      [
+                                        -5,
+                                        7
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b": [
+                                      [
+                                        0,
+                                        15
+                                      ],
+                                      [
+                                        -5,
+                                        13
+                                      ],
+                                      [
+                                        -3,
+                                        15
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b": [
+                                      [
+                                        5,
+                                        10
+                                      ],
+                                      [
+                                        3,
+                                        15
+                                      ],
+                                      [
+                                        5,
+                                        13
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b": [
+                                      [
+                                        0,
+                                        -2
+                                      ],
+                                      [
+                                        5,
+                                        7
+                                      ],
+                                      [
+                                        1,
+                                        5
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol": {
+                              "type": "CIMPolygonSymbol",
+                              "symbolLayers": [
+                                {
+                                  "type": "CIMSolidStroke",
+                                  "enable": true,
+                                  "capStyle": "Round",
+                                  "joinStyle": "Round",
+                                  "lineStyle3D": "Strip",
+                                  "miterLimit": 10,
+                                  "width": 0.5,
+                                  "height3D": 1,
+                                  "anchor3D": "Center",
+                                  "color": {
+                                    "type": "CIMRGBColor",
+                                    "values": [
+                                      255,
+                                      255,
+                                      255,
+                                      100
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type": "CIMSolidFill",
+                                  "enable": true,
+                                  "color": {
+                                    "type": "CIMRGBColor",
+                                    "values": [
+                                      190,
+                                      210,
+                                      255,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment": "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally": true,
+                        "respectFrame": true
+                      }
+                    ],
+                    "haloSize": 1,
+                    "scaleX": 1,
+                    "angleAlignment": "Display"
+                  }
+                },
+                "values": [
+                  {
+                    "type": "CIMUniqueValue",
+                    "fieldValues": [
+                      "Park und Pool"
+                    ]
+                  }
+                ],
+                "visible": true
+              },
+              {
+                "type": "CIMUniqueValueClass",
+                "editable": true,
+                "label": "Parkplatz",
+                "patch": "Default",
+                "symbol": {
+                  "type": "CIMSymbolReference",
+                  "symbol": {
+                    "type": "CIMPointSymbol",
+                    "symbolLayers": [
+                      {
+                        "type": "CIMVectorMarker",
+                        "enable": true,
+                        "name": "New_402cc530-33c7-4411-9f2a-912756015a46",
+                        "anchorPoint": {
+                          "x": -0.06,
+                          "y": -2.5,
+                          "z": 0
+                        },
+                        "anchorPointUnits": "Relative",
+                        "dominantSizeAxis3D": "Y",
+                        "size": 7,
+                        "billboardMode3D": "FaceNearPlane",
+                        "frame": {
+                          "xmin": -5,
+                          "ymin": -5,
+                          "xmax": 5,
+                          "ymax": 5
+                        },
+                        "markerGraphics": [
+                          {
+                            "type": "CIMMarkerGraphic",
+                            "geometry": {
+                              "x": 0,
+                              "y": 0
+                            },
+                            "symbol": {
+                              "type": "CIMTextSymbol",
+                              "blockProgression": "TTB",
+                              "depth3D": 1,
+                              "extrapolateBaselines": true,
+                              "fontEffects": "Normal",
+                              "fontEncoding": "Unicode",
+                              "fontFamilyName": "Tahoma",
+                              "fontStyleName": "Bold",
+                              "fontType": "Unspecified",
+                              "haloSize": 1,
+                              "height": 10,
+                              "hinting": "Default",
+                              "horizontalAlignment": "Center",
+                              "kerning": true,
+                              "letterWidth": 100,
+                              "ligatures": true,
+                              "lineGapType": "ExtraLeading",
+                              "symbol": {
+                                "type": "CIMPolygonSymbol",
+                                "symbolLayers": [
+                                  {
+                                    "type": "CIMSolidFill",
+                                    "enable": true,
+                                    "color": {
+                                      "type": "CIMRGBColor",
+                                      "values": [
+                                        255,
+                                        255,
+                                        255,
+                                        100
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "angleAlignment": "Map"
+                              },
+                              "symbol3DProperties": {
+                                "type": "CIM3DSymbolProperties",
+                                "dominantSizeAxis3D": "Z",
+                                "rotationOrder3D": "YXZ",
+                                "scaleZ": 1,
+                                "scaleY": 1
+                              },
+                              "textCase": "Normal",
+                              "textDirection": "LTR",
+                              "verticalAlignment": "Center",
+                              "verticalGlyphOrientation": "Right",
+                              "wordSpacing": 100,
+                              "billboardMode3D": "FaceNearPlane"
+                            },
+                            "textString": "P"
+                          }
+                        ],
+                        "scaleSymbolsProportionally": true,
+                        "respectFrame": true
+                      },
+                      {
+                        "type": "CIMVectorMarker",
+                        "enable": true,
+                        "name": "New_63a771a9-b0ba-48a5-8a10-b85f913a4cb2",
+                        "colorLocked": true,
+                        "anchorPoint": {
+                          "x": 0,
+                          "y": -1.55,
+                          "z": 0
+                        },
+                        "anchorPointUnits": "Relative",
+                        "dominantSizeAxis3D": "Y",
+                        "size": 11,
+                        "billboardMode3D": "FaceNearPlane",
+                        "frame": {
+                          "xmin": -5,
+                          "ymin": -5,
+                          "xmax": 5,
+                          "ymax": 5
+                        },
+                        "markerGraphics": [
+                          {
+                            "type": "CIMMarkerGraphic",
+                            "geometry": {
+                              "curveRings": [
+                                [
+                                  [
+                                    0,
+                                    5
+                                  ],
+                                  {
+                                    "a": [
+                                      [
+                                        0,
+                                        5
+                                      ],
+                                      [
+                                        7.79121370451716E-15,
+                                        0
+                                      ],
+                                      0,
+                                      1
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol": {
+                              "type": "CIMPolygonSymbol",
+                              "symbolLayers": [
+                                {
+                                  "type": "CIMSolidFill",
+                                  "enable": true,
+                                  "name": "New_f4631f39-444d-471a-bf1f-765b412a4f68",
+                                  "color": {
+                                    "type": "CIMRGBColor",
+                                    "values": [
+                                      0,
+                                      41,
+                                      240,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment": "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally": true,
+                        "respectFrame": true
+                      },
+                      {
+                        "type": "CIMVectorMarker",
+                        "enable": true,
+                        "colorLocked": true,
+                        "anchorPoint": {
+                          "x": 0,
+                          "y": -0.5
+                        },
+                        "anchorPointUnits": "Relative",
+                        "dominantSizeAxis3D": "Y",
+                        "size": 24,
+                        "billboardMode3D": "FaceNearPlane",
+                        "frame": {
+                          "xmin": -5,
+                          "ymin": -2,
+                          "xmax": 5,
+                          "ymax": 15
+                        },
+                        "markerGraphics": [
+                          {
+                            "type": "CIMMarkerGraphic",
+                            "geometry": {
+                              "curveRings": [
+                                [
+                                  [
+                                    0,
+                                    -2
+                                  ],
+                                  {
+                                    "b": [
+                                      [
+                                        -5,
+                                        10
+                                      ],
+                                      [
+                                        -1,
+                                        5
+                                      ],
+                                      [
+                                        -5,
+                                        7
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b": [
+                                      [
+                                        0,
+                                        15
+                                      ],
+                                      [
+                                        -5,
+                                        13
+                                      ],
+                                      [
+                                        -3,
+                                        15
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b": [
+                                      [
+                                        5,
+                                        10
+                                      ],
+                                      [
+                                        3,
+                                        15
+                                      ],
+                                      [
+                                        5,
+                                        13
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b": [
+                                      [
+                                        0,
+                                        -2
+                                      ],
+                                      [
+                                        5,
+                                        7
+                                      ],
+                                      [
+                                        1,
+                                        5
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol": {
+                              "type": "CIMPolygonSymbol",
+                              "symbolLayers": [
+                                {
+                                  "type": "CIMSolidStroke",
+                                  "enable": true,
+                                  "capStyle": "Round",
+                                  "joinStyle": "Round",
+                                  "lineStyle3D": "Strip",
+                                  "miterLimit": 10,
+                                  "width": 0.5,
+                                  "height3D": 1,
+                                  "anchor3D": "Center",
+                                  "color": {
+                                    "type": "CIMRGBColor",
+                                    "values": [
+                                      255,
+                                      255,
+                                      255,
+                                      100
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type": "CIMSolidFill",
+                                  "enable": true,
+                                  "color": {
+                                    "type": "CIMRGBColor",
+                                    "values": [
+                                      102,
+                                      119,
+                                      205,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment": "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally": true,
+                        "respectFrame": true
+                      }
+                    ],
+                    "haloSize": 1,
+                    "scaleX": 1,
+                    "angleAlignment": "Display"
+                  }
+                },
+                "values": [
+                  {
+                    "type": "CIMUniqueValue",
+                    "fieldValues": [
+                      "Parkplatz"
+                    ]
+                  }
+                ],
+                "visible": true
+              },
+              {
+                "type": "CIMUniqueValueClass",
+                "editable": true,
+                "label": "Rastplatz",
+                "patch": "Default",
+                "symbol": {
+                  "type": "CIMSymbolReference",
+                  "symbol": {
+                    "type": "CIMPointSymbol",
+                    "symbolLayers": [
+                      {
+                        "type": "CIMVectorMarker",
+                        "enable": true,
+                        "name": "New_981cf9bf-585e-4ddb-8149-38c86447831b",
+                        "anchorPoint": {
+                          "x": -0.06,
+                          "y": -2.5,
+                          "z": 0
+                        },
+                        "anchorPointUnits": "Relative",
+                        "dominantSizeAxis3D": "Y",
+                        "size": 7,
+                        "billboardMode3D": "FaceNearPlane",
+                        "frame": {
+                          "xmin": -5,
+                          "ymin": -5,
+                          "xmax": 5,
+                          "ymax": 5
+                        },
+                        "markerGraphics": [
+                          {
+                            "type": "CIMMarkerGraphic",
+                            "geometry": {
+                              "x": 0,
+                              "y": 0
+                            },
+                            "symbol": {
+                              "type": "CIMTextSymbol",
+                              "blockProgression": "TTB",
+                              "depth3D": 1,
+                              "extrapolateBaselines": true,
+                              "fontEffects": "Normal",
+                              "fontEncoding": "Unicode",
+                              "fontFamilyName": "Tahoma",
+                              "fontStyleName": "Bold",
+                              "fontType": "Unspecified",
+                              "haloSize": 1,
+                              "height": 10,
+                              "hinting": "Default",
+                              "horizontalAlignment": "Center",
+                              "kerning": true,
+                              "letterWidth": 100,
+                              "ligatures": true,
+                              "lineGapType": "ExtraLeading",
+                              "symbol": {
+                                "type": "CIMPolygonSymbol",
+                                "symbolLayers": [
+                                  {
+                                    "type": "CIMSolidFill",
+                                    "enable": true,
+                                    "color": {
+                                      "type": "CIMRGBColor",
+                                      "values": [
+                                        255,
+                                        255,
+                                        255,
+                                        100
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "angleAlignment": "Map"
+                              },
+                              "symbol3DProperties": {
+                                "type": "CIM3DSymbolProperties",
+                                "dominantSizeAxis3D": "Z",
+                                "rotationOrder3D": "YXZ",
+                                "scaleZ": 1,
+                                "scaleY": 1
+                              },
+                              "textCase": "Normal",
+                              "textDirection": "LTR",
+                              "verticalAlignment": "Center",
+                              "verticalGlyphOrientation": "Right",
+                              "wordSpacing": 100,
+                              "billboardMode3D": "FaceNearPlane"
+                            },
+                            "textString": "P"
+                          }
+                        ],
+                        "scaleSymbolsProportionally": true,
+                        "respectFrame": true
+                      },
+                      {
+                        "type": "CIMVectorMarker",
+                        "enable": true,
+                        "name": "New_0892beed-cd7f-4aac-9961-7f438ab6bd0e",
+                        "colorLocked": true,
+                        "anchorPoint": {
+                          "x": 0,
+                          "y": -1.55,
+                          "z": 0
+                        },
+                        "anchorPointUnits": "Relative",
+                        "dominantSizeAxis3D": "Y",
+                        "size": 11,
+                        "billboardMode3D": "FaceNearPlane",
+                        "frame": {
+                          "xmin": -5,
+                          "ymin": -5,
+                          "xmax": 5,
+                          "ymax": 5
+                        },
+                        "markerGraphics": [
+                          {
+                            "type": "CIMMarkerGraphic",
+                            "geometry": {
+                              "curveRings": [
+                                [
+                                  [
+                                    0,
+                                    5
+                                  ],
+                                  {
+                                    "a": [
+                                      [
+                                        0,
+                                        5
+                                      ],
+                                      [
+                                        6.824245263706025E-15,
+                                        0
+                                      ],
+                                      0,
+                                      1
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol": {
+                              "type": "CIMPolygonSymbol",
+                              "symbolLayers": [
+                                {
+                                  "type": "CIMSolidFill",
+                                  "enable": true,
+                                  "name": "New_f4631f39-444d-471a-bf1f-765b412a4f68",
+                                  "color": {
+                                    "type": "CIMRGBColor",
+                                    "values": [
+                                      0,
+                                      41,
+                                      240,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment": "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally": true,
+                        "respectFrame": true
+                      },
+                      {
+                        "type": "CIMVectorMarker",
+                        "enable": true,
+                        "colorLocked": true,
+                        "anchorPoint": {
+                          "x": 0,
+                          "y": -0.5
+                        },
+                        "anchorPointUnits": "Relative",
+                        "dominantSizeAxis3D": "Y",
+                        "size": 24,
+                        "billboardMode3D": "FaceNearPlane",
+                        "frame": {
+                          "xmin": -5,
+                          "ymin": -2,
+                          "xmax": 5,
+                          "ymax": 15
+                        },
+                        "markerGraphics": [
+                          {
+                            "type": "CIMMarkerGraphic",
+                            "geometry": {
+                              "curveRings": [
+                                [
+                                  [
+                                    0,
+                                    -2
+                                  ],
+                                  {
+                                    "b": [
+                                      [
+                                        -5,
+                                        10
+                                      ],
+                                      [
+                                        -1,
+                                        5
+                                      ],
+                                      [
+                                        -5,
+                                        7
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b": [
+                                      [
+                                        0,
+                                        15
+                                      ],
+                                      [
+                                        -5,
+                                        13
+                                      ],
+                                      [
+                                        -3,
+                                        15
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b": [
+                                      [
+                                        5,
+                                        10
+                                      ],
+                                      [
+                                        3,
+                                        15
+                                      ],
+                                      [
+                                        5,
+                                        13
+                                      ]
+                                    ]
+                                  },
+                                  {
+                                    "b": [
+                                      [
+                                        0,
+                                        -2
+                                      ],
+                                      [
+                                        5,
+                                        7
+                                      ],
+                                      [
+                                        1,
+                                        5
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              ]
+                            },
+                            "symbol": {
+                              "type": "CIMPolygonSymbol",
+                              "symbolLayers": [
+                                {
+                                  "type": "CIMSolidStroke",
+                                  "enable": true,
+                                  "capStyle": "Round",
+                                  "joinStyle": "Round",
+                                  "lineStyle3D": "Strip",
+                                  "miterLimit": 10,
+                                  "width": 0.5,
+                                  "height3D": 1,
+                                  "anchor3D": "Center",
+                                  "color": {
+                                    "type": "CIMRGBColor",
+                                    "values": [
+                                      255,
+                                      255,
+                                      255,
+                                      100
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type": "CIMSolidFill",
+                                  "enable": true,
+                                  "color": {
+                                    "type": "CIMRGBColor",
+                                    "values": [
+                                      255,
+                                      219.93,
+                                      0,
+                                      100
+                                    ]
+                                  }
+                                }
+                              ],
+                              "angleAlignment": "Map"
+                            }
+                          }
+                        ],
+                        "scaleSymbolsProportionally": true,
+                        "respectFrame": true
+                      }
+                    ],
+                    "haloSize": 1,
+                    "scaleX": 1,
+                    "angleAlignment": "Display"
+                  }
+                },
+                "values": [
+                  {
+                    "type": "CIMUniqueValue",
+                    "fieldValues": [
+                      "Rastplatz"
+                    ]
+                  }
+                ],
+                "visible": true
+              }
+            ],
+            "heading": "Nutzung"
+          }
+        ],
+        "isDefaultSymbolVisible": true,
+        "polygonSymbolColorTarget": "Fill"
+      },
+      "scaleSymbols": true,
+      "snappable": true
+    }
+  ]
+}


### PR DESCRIPTION
Fix symbol sizing for nested geometries and circles

- Use outer frame for nested symbol scaling to ensure consistent sizes
- Apply empirical 1.5 factor for simple circle markers
- Rename OFFSET_FACTOR to SCALE_FACTOR (3/2)
- Simplify processSymbolVectorMarker with helper function