### PR TITLE
fix(#165): fix image inlineContent dimensions

### DIFF
--- a/src/base64Utils.ts
+++ b/src/base64Utils.ts
@@ -57,9 +57,14 @@ export const resizeBase64Image = async (
   let resizedBase64Image: string | undefined;
   try {
     const image = await Jimp.read(buffer);
+    const newDimensions = scaleToSize(
+      size,
+      image.bitmap.height,
+      image.bitmap.width,
+    );
     const resizedImage = image.resize({
-      w: Math.floor(size),
-      h: Math.floor(size),
+      h: newDimensions[0],
+      w: newDimensions[1],
     });
     resizedBase64Image = await resizedImage.getBase64(mimeType);
   } catch (e) {
@@ -69,4 +74,20 @@ export const resizeBase64Image = async (
     return resizedBase64Image;
   }
   return base64String;
+};
+
+/**
+ * Use the given size as the new max side size and scale the other side proportionally.
+ */
+export const scaleToSize = (
+  newMaxSize: number,
+  height: number,
+  width: number,
+): [number, number] => {
+  const ratio = newMaxSize / Math.max(height, width);
+  const newMin = ratio * Math.min(height, width);
+  return [
+    height > width ? newMaxSize : newMin,
+    width > height ? newMaxSize : newMin,
+  ];
 };

--- a/tests/ut/base64Utils.spec.ts
+++ b/tests/ut/base64Utils.spec.ts
@@ -1,0 +1,14 @@
+import { expect, it, describe } from "vitest";
+import { scaleToSize } from "../../src/base64Utils";
+
+describe("base64Utils", () => {
+  it("scaleToSize", () => {
+    expect(scaleToSize(40, 40, 40)).toEqual([40, 40]);
+    // Smaller new size
+    expect(scaleToSize(20, 80, 40)).toEqual([20, 10]);
+    expect(scaleToSize(20, 40, 80)).toEqual([10, 20]);
+    // bigger new size
+    expect(scaleToSize(160, 80, 40)).toEqual([160, 80]);
+    expect(scaleToSize(160, 40, 80)).toEqual([80, 160]);
+  });
+});


### PR DESCRIPTION
Fix #165

Scale the biggest side of the image to the wanted size and keep the ratio for the other side. 